### PR TITLE
Versioned images are built incorrectly.

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -3,7 +3,8 @@ FROM python:${VERSION}-buster
 
 COPY requirements-api.txt /tmp/
 
-RUN pip3 install -r /tmp/requirements-api.txt \
+RUN python3 -m pip -qq install --upgrade pip \
+  && python3 -m pip -qq install -r /tmp/requirements-api.txt \
   && rm -f /tmp/requirements-api.txt
 
 ENV USER=api

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,22 +5,22 @@ tasks:
   api:
     desc: Build a docker environment with the right dependencies and utilities
     cmds:
-      - docker build --no-cache --build-arg 3.6 -f Dockerfile-api -t jitsuin-samples-api .
+      - docker build --no-cache --build-arg VERSION=3.6 -f Dockerfile-api -t jitsuin-samples-api .
 
   api-3.7:
     desc: Build a docker environment with the right dependencies and utilities
     cmds:
-      - docker build --no-cache --build-arg 3.7 -f Dockerfile-api -t jitsuin-samples-api .
+      - docker build --no-cache --build-arg VERSION=3.7 -f Dockerfile-api -t jitsuin-samples-api .
 
   api-3.8:
     desc: Build a docker environment with the right dependencies and utilities
     cmds:
-      - docker build --no-cache --build-arg 3.8 -f Dockerfile-api -t jitsuin-samples-api .
+      - docker build --no-cache --build-arg VERSION=3.8 -f Dockerfile-api -t jitsuin-samples-api .
   
   api-3.9:
     desc: Build a docker environment with the right dependencies and utilities
     cmds:
-      - docker build --no-cache --build-arg 3.9 -f Dockerfile-api -t jitsuin-samples-api .
+      - docker build --no-cache --build-arg VERSION=3.9 -f Dockerfile-api -t jitsuin-samples-api .
 
   check:
     desc: Check the style, bug and quality of the code

--- a/example-commit
+++ b/example-commit
@@ -1,0 +1,10 @@
+A meaningful concise title
+    
+Problem:
+Clear succinct statement of problem.
+    
+Solution:
+Summarised description of solution.
+    
+Signed-off-by: User Name <user@email.com>
+

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -2,7 +2,7 @@
 # code quality
 autopep8==1.5.5
 black==21.4b2
-cryptography==2.8
+cryptography==3.2
 pycodestyle==2.6.0
 pylint==2.6.0
 pyyaml==5.4.1


### PR DESCRIPTION
Problem:
Versioned docker images have incorrectly specified build-args.

Solution:
Added VERSION= in build-args. Additionally upgraded pip and suppressed
annoying warning messages.

Signed-off-by: eccles <phewlett76@gmail.com>