### PR TITLE
Update cryptogrpahy dependencies to keep up with security patches

### DIFF
--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -2,7 +2,7 @@
 # code quality
 autopep8==1.5.5
 black==21.4b2
-cryptography==3.2
+cryptography==3.3.2
 pycodestyle==2.6.0
 pylint==2.6.0
 pyyaml==5.4.1


### PR DESCRIPTION
Problem:
Outdated version of cryptography library used in samples.

Solution:
Updated dependency list to currently recommended version.

Signed-off-by: JAG-UK <jon.geater@gmail.com>