### PR TITLE
Remove root logger from archivist dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dist/
 .coverage
 *,cover
 *.xml
+*.pem
+*.aid
 htmlcov/
 .local/
 .pylint.d/

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -3,12 +3,17 @@
 Sample python code that uses the archivist python SDK to manage particular types of assets
 such as 'doors', 'cards', 'containers' etc.
 
+This document describes how to test any modifications made to the codebase.
+
 # Developer Pre-requisites
 
 Required tools for modifying this repo are task-runner and docker-ce.
 
   - Install task runner: https://github.com/go-task/task
   - Install docker-ce: https://docs.docker.com/get-docker/
+
+A running archivist instance which allows creation of arbitrary assets etc. This is usually
+a test or demo system and **not** a production system.
 
 # Running the samples code
 

--- a/README.md
+++ b/README.md
@@ -33,65 +33,81 @@ export NAMESPACE="unique label"
 export VERBOSE=-v
 ```
 
-If VERBOSE is "-v" debugging output will appear when running the tests. Otherwise leave blank or undefined.
+If VERBOSE is "-v" debugging output will appear when running the examples. Otherwise leave blank or undefined.
 
 ## NAMESPACE
 
-If NAMESPACE is blank or unspecified then each execution of './scripts/samples.sh' will not be
-independent. Any assets events, locations will be visible to other users running the same tests
+If NAMESPACE is blank or unspecified, any assets events, locations will be visible to other users running the same examples
 on the same URL.
 
-Each example test creates assets,events,locations that are not visible to other example tests.
-For example the door_entry assets,events etc are not visible to the synsation example tests.
+Each example creates assets,events,locations that are not visible to other examples.
+For example the door_entry assets,events etc are not visible to the synsation example.
 
 Assets and locations are only created if they do not already exist according to namespace.
 
-Due to restrictions attachments are always uploaded during every test execution.
+Due to restrictions attachments are always uploaded during every example execution.
 
-Events are created every execution of a test - currently no check is done if the event already exists.
+Events are created every execution of an example - currently no check is done if the event already exists.
 
-## TESTS
+## EXAMPLES
 
-Move to correct subdirectory:
+All examples use a common set of arguments:
+
+```bash
+export AUTH="-u $ARCHIVIST -t $AUTHTOKEN $VERBOSE"
+export ARGS="$AUTH --namespace $NAMESPACE"
+```
 
 ### Door Entry Control
 
 Some commands to simply create and manage doors and cards:
 
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --create
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --list all
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --list doors
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --list cards
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --list 'Courts of Justice front door'
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --list 'access_card_1'
+```bash
+archivist_samples_door_entry $ARGS --create
+archivist_samples_door_entry $ARGS --list all
+archivist_samples_door_entry $ARGS --list doors
+archivist_samples_door_entry $ARGS --list cards
+archivist_samples_door_entry $ARGS --list 'Courts of Justice front door'
+archivist_samples_door_entry $ARGS --list 'access_card_1'
+```
 
 Execute opening doors with a card:
 
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --open "Courts of Justice front door,access_card_1"
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --open "Courts of Justice front door,access_card_3"
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --open "Courts of Justice front door,access_card_4"
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --open "Courts of Justice front door,access_card_0"
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --open "Courts of Justice front door,access_card_2"
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --open "Bastille front door,access_card_2"
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --open "City Hall front door,access_card_2"
-archivist_samples_door_entry -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --open "Gare du Nord apartments side door,access_card_2"
+```bash
+archivist_samples_door_entry $ARGS --open "Courts of Justice front door,access_card_1"
+archivist_samples_door_entry $ARGS --open "Courts of Justice front door,access_card_3"
+archivist_samples_door_entry $ARGS --open "Courts of Justice front door,access_card_4"
+archivist_samples_door_entry $ARGS --open "Courts of Justice front door,access_card_0"
+archivist_samples_door_entry $ARGS --open "Courts of Justice front door,access_card_2"
+archivist_samples_door_entry $ARGS --open "Bastille front door,access_card_2"
+archivist_samples_door_entry $ARGS --open "City Hall front door,access_card_2"
+archivist_samples_door_entry $ARGS --open "Gare du Nord apartments side door,access_card_2"
+```
 
 ### Manage assets and events and check for any inconsistencies
 
-archivist_samples_estate_info -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --quick-count
-archivist_samples_estate_info -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --double-check
+NB no namespace required ...
+
+```bash
+archivist_samples_estate_info $AUTH --quick-count
+archivist_samples_estate_info $AUTH --double-check
+```
 
 ### Signed Records
 
-archivist_samples_signed_records -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --create 'samples'
-archivist_samples_signed_records -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --sign-message 'signature' 'samples'
-archivist_samples_signed_records -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --bad-sign-message 'signature' 'samples'
-archivist_samples_signed_records -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --check 'samples'
+```bash
+archivist_samples_signed_records $ARGS --create 'samples'
+archivist_samples_signed_records $ARGS --sign-message 'signature' 'samples'
+archivist_samples_signed_records $ARGS --bad-sign-message 'signature' 'samples'
+archivist_samples_signed_records $ARGS --check 'samples'
+```
 
 ### Synsation
 
-archivist_samples_synsation initialise  -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE --num-assets 100 --wait 1 --await-confirmation
-archivist_samples_synsation analyze     -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE
-archivist_samples_synsation charger     -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE -s 20190909 -S 20190923 -f 9876
-archivist_samples_synsation jitsuinator -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE -n tcl.ccj.001 --wait 1.0
-archivist_samples_synsation wanderer    -u $ARCHIVIST -t $AUTHTOKEN $VERBOSE --namespace $NAMESPACE
+```bash
+archivist_samples_synsation initialise  $ARGS --num-assets 100 --wait 1 --await-confirmation
+archivist_samples_synsation analyze     $ARGS 
+archivist_samples_synsation charger     $ARGS -s 20190909 -S 20190923 -f 9876
+archivist_samples_synsation jitsuinator $ARGS -n tcl.ccj.001 --wait 1.0
+archivist_samples_synsation wanderer    $ARGS
+```

--- a/archivist_samples/door_entry/main.py
+++ b/archivist_samples/door_entry/main.py
@@ -22,7 +22,8 @@ from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
 from archivist.archivist import Archivist
-from archivist.logger import set_logger, LOGGER
+
+from ..testing.logger import set_logger, LOGGER
 
 from .run import run
 

--- a/archivist_samples/door_entry/run.py
+++ b/archivist_samples/door_entry/run.py
@@ -17,12 +17,12 @@
 # pylint:  disable=missing-docstring
 
 
+import logging
 from sys import exit as sys_exit
 import uuid
 
 from archivist import about
 from archivist.errors import ArchivistNotFoundError
-from archivist.logger import LOGGER
 
 from ..testing.namespace import (
     assets_create,
@@ -46,6 +46,8 @@ BEHAVIOURS = [
 ]
 
 IMAGEDIR = "archivist_samples/door_entry/images"
+
+LOGGER = logging.getLogger(__name__)
 
 
 # Door asset

--- a/archivist_samples/estate_info/main.py
+++ b/archivist_samples/estate_info/main.py
@@ -26,7 +26,8 @@ from sys import stdout as sys_stdout
 
 from archivist import about
 from archivist.archivist import Archivist
-from archivist.logger import set_logger, LOGGER
+
+from ..testing.logger import set_logger, LOGGER
 
 # Main app
 ##########

--- a/archivist_samples/signed_records/main.py
+++ b/archivist_samples/signed_records/main.py
@@ -41,7 +41,8 @@ from cryptography.hazmat import backends
 from archivist import about
 from archivist.archivist import Archivist
 from archivist.errors import ArchivistNotFoundError
-from archivist.logger import set_logger, LOGGER
+
+from ..testing.logger import set_logger, LOGGER
 
 from ..testing.namespace import (
     assets_create,

--- a/archivist_samples/synsation/analyze.py
+++ b/archivist_samples/synsation/analyze.py
@@ -26,9 +26,9 @@ from sys import stdout as sys_stdout
 
 from archivist import about
 from archivist.archivist import Archivist
-from archivist.logger import set_logger, LOGGER
 from archivist.timestamp import parse_timestamp
 
+from ..testing.logger import set_logger, LOGGER
 from ..testing.namespace import (
     assets_list,
     events_count,

--- a/archivist_samples/synsation/charger.py
+++ b/archivist_samples/synsation/charger.py
@@ -29,8 +29,8 @@ import time
 
 from archivist import about
 from archivist.archivist import Archivist
-from archivist.logger import set_logger, LOGGER
 
+from ..testing.logger import set_logger, LOGGER
 from ..testing.time_warp import TimeWarp
 
 from ..testing.namespace import (

--- a/archivist_samples/synsation/ev_charger_device.py
+++ b/archivist_samples/synsation/ev_charger_device.py
@@ -18,10 +18,10 @@
 # pylint: disable=missing-docstring
 
 
+import logging
 import threading
 import uuid
 
-from archivist.logger import LOGGER
 from archivist.timestamp import make_timestamp
 
 from ..testing.namespace import (
@@ -30,6 +30,8 @@ from ..testing.namespace import (
 
 from . import maintenance_worker
 from .util import make_event_json
+
+LOGGER = logging.getLogger(__name__)
 
 
 class EVDevice:

--- a/archivist_samples/synsation/initialise.py
+++ b/archivist_samples/synsation/initialise.py
@@ -25,8 +25,8 @@ from sys import stdout as sys_stdout
 
 from archivist import about
 from archivist.archivist import Archivist
-from archivist.logger import set_logger, LOGGER
 
+from ..testing.logger import set_logger, LOGGER
 from ..testing.namespace import assets_wait_for_confirmed
 
 from . import synsation_corporation

--- a/archivist_samples/synsation/jitsuinator.py
+++ b/archivist_samples/synsation/jitsuinator.py
@@ -31,9 +31,9 @@ import uuid
 from archivist import about
 from archivist.archivist import Archivist
 from archivist.errors import ArchivistNotFoundError
-from archivist.logger import set_logger, LOGGER
 from archivist.timestamp import make_timestamp
 
+from ..testing.logger import set_logger, LOGGER
 from ..testing.namespace import (
     assets_read_by_signature,
     events_create,

--- a/archivist_samples/synsation/maintenance_worker.py
+++ b/archivist_samples/synsation/maintenance_worker.py
@@ -17,13 +17,15 @@
 
 # pylint: disable=missing-docstring
 
+import logging
 import random
 import time
 
-from archivist.logger import LOGGER
 from archivist.timestamp import make_timestamp
 
 from .util import make_event_json
+
+LOGGER = logging.getLogger(__name__)
 
 
 def service_device(charger, job_id, timewarp):

--- a/archivist_samples/synsation/recall_worker.py
+++ b/archivist_samples/synsation/recall_worker.py
@@ -17,17 +17,19 @@
 
 # pylint: disable=missing-docstring
 
-import random
 import datetime
+import logging
+import random
 import time
 import threading
 import uuid
 
-from archivist.logger import LOGGER
 from archivist.timestamp import make_timestamp
 
 from . import patch_worker
 from .util import make_event_json
+
+LOGGER = logging.getLogger(__name__)
 
 
 def issue_recall(charger_list, cve_str, timewarp):

--- a/archivist_samples/synsation/synsation_corporation.py
+++ b/archivist_samples/synsation/synsation_corporation.py
@@ -16,10 +16,9 @@
 
 # pylint: disable=missing-docstring
 
+import logging
 import random
 import time
-
-from archivist.logger import LOGGER
 
 from ..testing.namespace import (
     locations_create_from_yaml_file,
@@ -29,6 +28,8 @@ from .util import (
     assets_create_if_not_exists,
     attachments_read_from_file,
 )
+
+LOGGER = logging.getLogger(__name__)
 
 LOCATIONS_DIR = "archivist_samples/synsation/locations"
 

--- a/archivist_samples/synsation/synsation_industries.py
+++ b/archivist_samples/synsation/synsation_industries.py
@@ -20,12 +20,13 @@
 
 # pylint: disable=missing-docstring
 
+import logging
 import random
 import string
 
-from archivist.logger import LOGGER
-
 from .util import assets_create_if_not_exists, attachments_read_from_file
+
+LOGGER = logging.getLogger(__name__)
 
 
 def initialise_asset_types(ac):

--- a/archivist_samples/synsation/synsation_smartcity.py
+++ b/archivist_samples/synsation/synsation_smartcity.py
@@ -16,9 +16,11 @@
 
 # pylint: disable=missing-docstring
 
-from archivist.logger import LOGGER
+import logging
 
 from .util import assets_create_if_not_exists, attachments_read_from_file
+
+LOGGER = logging.getLogger(__name__)
 
 
 def initialise_asset_types(ac):

--- a/archivist_samples/synsation/wanderer.py
+++ b/archivist_samples/synsation/wanderer.py
@@ -27,9 +27,9 @@ import time
 from archivist import about
 from archivist.archivist import Archivist
 from archivist.errors import ArchivistNotFoundError
-from archivist.logger import set_logger, LOGGER
 from archivist.timestamp import make_timestamp
 
+from ..testing.logger import set_logger, LOGGER
 from ..testing.namespace import (
     assets_list,
     assets_read_by_signature,

--- a/archivist_samples/testing/__init__.py
+++ b/archivist_samples/testing/__init__.py
@@ -1,3 +1,3 @@
-"""Some stuff required for running example code
-   that should not be part of the installable wheel
+"""Convenience layer that ensures that assets and locations are created, read or
+   counted for a particular namespace plus a logger interface.
 """

--- a/archivist_samples/testing/accesscontrol.py
+++ b/archivist_samples/testing/accesscontrol.py
@@ -18,10 +18,12 @@
 
 import datetime
 import json
+import logging
 import requests
 
 from archivist.archivist import Archivist
-from archivist.logger import LOGGER
+
+LOGGER = logging.getLogger(__name__)
 
 # Types
 #######

--- a/archivist_samples/testing/logger.py
+++ b/archivist_samples/testing/logger.py
@@ -1,0 +1,36 @@
+"""Creates the root logger as a simple console streamer. Follows the Django-style
+   logging configuration where the logging system forms a hierarchy of loggers
+   all potentially independently configurable.
+
+   This model allows controlling loggers that are part of the dependency list. For
+   example setting a debug logging level will show debug output from the underlying
+   urllib3 package.
+
+   URL: https://docs.djangoproject.com/en/3.2/topics/logging/
+"""
+
+# pylint:  disable=missing-docstring
+
+import logging
+import logging.config
+
+# root logger for all code
+LOGGER = logging.getLogger()
+
+
+def set_logger(level):
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                },
+            },
+            "root": {
+                "handlers": ["console"],
+                "level": level,
+            },
+        }
+    )

--- a/archivist_samples/testing/time_warp.py
+++ b/archivist_samples/testing/time_warp.py
@@ -1,4 +1,5 @@
-"""Simulates accelerated time for creating plausible logs quickly"""
+"""Simulates accelerated time for creating plausible logs quickly
+"""
 
 import datetime
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 cryptography==3.3.2
-jitsuin-archivist==0.1.0a5
+jitsuin-archivist==0.2.0a2


### PR DESCRIPTION
Problem:
The root logger in the archivist dependency used a predefined settings.

Solution:
Upgrade to archivist0.2.0a1 and use default root logger settings with
helper module.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>