### PR TITLE
Missing yaml dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cryptography==3.3.2
 jitsuin-archivist==0.2.0a2
+pyyaml==5.4.1


### PR DESCRIPTION
Problem:
The pyyaml package is missing from dependency list.

Solution:
Add pyyaml to requirements.tx.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>