### PR TITLE
Data files missing from wheel package.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+graft archivist_samples/door_entry/images
+graft archivist_samples/synsation/images
+graft archivist_samples/synsation/locations

--- a/archivist_samples/door_entry/images/__init__.py
+++ b/archivist_samples/door_entry/images/__init__.py
@@ -1,0 +1,2 @@
+"""For pkg_resources of importing data files
+"""

--- a/archivist_samples/door_entry/images/assets/__init__.py
+++ b/archivist_samples/door_entry/images/assets/__init__.py
@@ -1,0 +1,2 @@
+"""For pkg_resources of importing data files
+"""

--- a/archivist_samples/door_entry/images/events/__init__.py
+++ b/archivist_samples/door_entry/images/events/__init__.py
@@ -1,0 +1,2 @@
+"""For pkg_resources of importing data files
+"""

--- a/archivist_samples/door_entry/run.py
+++ b/archivist_samples/door_entry/run.py
@@ -17,12 +17,21 @@
 # pylint:  disable=missing-docstring
 
 
+try:
+    import importlib.resources as pkg_resources
+except ImportError:
+    # Try backported to PY<37 `importlib_resources`.
+    import importlib_resources as pkg_resources
+
 import logging
 from sys import exit as sys_exit
 import uuid
 
 from archivist import about
 from archivist.errors import ArchivistNotFoundError
+
+from .images import assets as images_assets
+from .images import events as images_events
 
 from ..testing.namespace import (
     assets_create,
@@ -44,8 +53,6 @@ BEHAVIOURS = [
     "Maintenance",
     "RecordEvidence",
 ]
-
-IMAGEDIR = "archivist_samples/door_entry/images"
 
 LOGGER = logging.getLogger(__name__)
 
@@ -217,7 +224,7 @@ def create_jitsuin_paris_site(arch):
 
 
 def create_jitsuin_paris_image(arch):
-    with open(f"{IMAGEDIR}/assets/entry_terminal.jpg", "rb") as fd:
+    with pkg_resources.open_binary(images_assets, "entry_terminal.jpg") as fd:
         return arch.attachments.upload(fd)
 
 
@@ -254,7 +261,7 @@ def create_cityhall_site(arch):
 
 
 def create_cityhall_image(arch):
-    with open(f"{IMAGEDIR}/assets/cityhall.jpg", "rb") as fd:
+    with pkg_resources.open_binary(images_assets, "cityhall.jpg") as fd:
         return arch.attachments.upload(fd)
 
 
@@ -289,7 +296,7 @@ def create_courts_site(arch):
 
 
 def create_courts_image(arch):
-    with open(f"{IMAGEDIR}/assets/courts.jpg", "rb") as fd:
+    with pkg_resources.open_binary(images_assets, "courts.jpg") as fd:
         return arch.attachments.upload(fd)
 
 
@@ -323,7 +330,7 @@ def create_bastille_site(arch):
 
 
 def create_bastille_image(arch):
-    with open(f"{IMAGEDIR}/assets/bastille.jpg", "rb") as fd:
+    with pkg_resources.open_binary(images_assets, "bastille.jpg") as fd:
         return arch.attachments.upload(fd)
 
 
@@ -360,7 +367,7 @@ def create_gdn_site(arch):
 
 
 def create_gdn_front_image(arch):
-    with open(f"{IMAGEDIR}/assets/gdn_front.jpg", "rb") as fd:
+    with pkg_resources.open_binary(images_assets, "gdn_front.jpg") as fd:
         return arch.attachments.upload(fd)
 
 
@@ -381,7 +388,7 @@ def create_gdn_front(arch, location, attachments):
 
 
 def create_gdn_side_image(arch):
-    with open(f"{IMAGEDIR}/assets/gdn_side.jpg", "rb") as fd:
+    with pkg_resources.open_binary(images_assets, "gdn_side.jpg") as fd:
         return arch.attachments.upload(fd)
 
 
@@ -608,7 +615,7 @@ def open_door(arch, doorid, cardid):
     # time but if the use case demands it is perfectly possible to
     # attach the same attachment ID to multiple assets/events rather
     # than duplicating them
-    with open(f"{IMAGEDIR}/events/dooropen.png", "rb") as fd:
+    with pkg_resources.open_binary(images_events, "dooropen.png") as fd:
         image = arch.attachments.upload(fd)
 
     # Issue RecordEvidence logs on each.

--- a/archivist_samples/synsation/ev_charger_device.py
+++ b/archivist_samples/synsation/ev_charger_device.py
@@ -97,7 +97,11 @@ class EVDevice:
         )
         attrs["arc_evidence"] = evidence_msg
         events_create(
-            self._archivist_client, self._archivist_asset_identity, props, attrs
+            self._archivist_client,
+            self._archivist_asset_identity,
+            props,
+            attrs,
+            confirm=True,
         )
 
     def service(self, timewarp):
@@ -126,7 +130,11 @@ class EVDevice:
                 corval,
             )
             events_create(
-                self._archivist_client, self._archivist_asset_identity, props, attrs
+                self._archivist_client,
+                self._archivist_asset_identity,
+                props,
+                attrs,
+                confirm=True,
             )
 
             # Call the maintenance crew
@@ -173,4 +181,5 @@ class EVDevice:
                 props,
                 attrs,
                 asset_attrs=asset_attrs,
+                confirm=True,
             )

--- a/archivist_samples/synsation/images/__init__.py
+++ b/archivist_samples/synsation/images/__init__.py
@@ -1,0 +1,2 @@
+"""For pkg_resources of importing data files
+"""

--- a/archivist_samples/synsation/images/assets/__init__.py
+++ b/archivist_samples/synsation/images/assets/__init__.py
@@ -1,0 +1,2 @@
+"""For pkg_resources of importing data files
+"""

--- a/archivist_samples/synsation/initialise.py
+++ b/archivist_samples/synsation/initialise.py
@@ -55,6 +55,7 @@ def run(ac, args):
 
     # Wait for all assets to confirm before we do anything with them
     if args.await_confirmation:
+        LOGGER.info("Wait for confirmation")
         assets_wait_for_confirmed(ac, attrs={"company": "synsation"})
 
     sys_exit(0)

--- a/archivist_samples/synsation/jitsuinator.py
+++ b/archivist_samples/synsation/jitsuinator.py
@@ -40,7 +40,7 @@ from ..testing.namespace import (
 )
 from ..testing.time_warp import TimeWarp
 
-from .util import make_event_json, attachments_read_from_file
+from .util import make_event_json, attachment_upload_from_file
 
 
 def demo_flow(ac, asset_id, asset_type, tw, wait):
@@ -82,7 +82,13 @@ def demo_flow(ac, asset_id, asset_type, tw, wait):
     )
     attrs["arc_cve_id"] = "CVE2020-deadbeef"
 
-    events_create(ac, asset_id, props, attrs)
+    events_create(
+        ac,
+        asset_id,
+        props,
+        attrs,
+        confirm=True,
+    )
 
     # -> OEM fixes it and issues the patch
     if wait:
@@ -106,7 +112,13 @@ def demo_flow(ac, asset_id, asset_type, tw, wait):
         "SHA256-sum for official 1.6 release: "
         "68ada47318341d060c387a765dd854b57334ab1f7322d22c155428414feb7518"
     )
-    events_create(ac, asset_id, props, attrs)
+    events_create(
+        ac,
+        asset_id,
+        props,
+        attrs,
+        confirm=True,
+    )
 
     # -> Integrator approves the patch and issues new safety certificate
     if wait:
@@ -115,10 +127,10 @@ def demo_flow(ac, asset_id, asset_type, tw, wait):
     else:
         input("Press to enact Integrator approves")
 
-    iattachment = attachments_read_from_file(
+    iattachment = attachment_upload_from_file(
         ac, "trafficlightconformance.png", "image/png"
     )
-    rattachment = attachments_read_from_file(
+    rattachment = attachment_upload_from_file(
         ac, "trafficlightconformance.pdf", "application/pdf"
     )
 
@@ -150,7 +162,13 @@ def demo_flow(ac, asset_id, asset_type, tw, wait):
             "arc_hash_alg": rattachment["hash"]["alg"],
         },
     ]
-    events_create(ac, asset_id, props, attrs)
+    events_create(
+        ac,
+        asset_id,
+        props,
+        attrs,
+        confirm=True,
+    )
 
     # -> Owner accepts new version and issues maintenance request to have it installed
     if wait:
@@ -171,7 +189,13 @@ def demo_flow(ac, asset_id, asset_type, tw, wait):
         maint_msg,
         job_corval,
     )
-    events_create(ac, asset_id, props, attrs)
+    events_create(
+        ac,
+        asset_id,
+        props,
+        attrs,
+        confirm=True,
+    )
 
     # -> Operator schedules downtime and patches it
     if wait:
@@ -192,7 +216,13 @@ def demo_flow(ac, asset_id, asset_type, tw, wait):
         maint_msg,
         job_corval,
     )
-    events_create(ac, asset_id, props, attrs)
+    events_create(
+        ac,
+        asset_id,
+        props,
+        attrs,
+        confirm=True,
+    )
 
     patch_msg = "Responding to vulnerability 'CVE2020-deadbeef' with patch 'v1.6'"
     props, attrs = make_event_json(
@@ -207,7 +237,14 @@ def demo_flow(ac, asset_id, asset_type, tw, wait):
     attrs["arc_firmware_version"] = "1.6"
     asset_attrs = {}
     asset_attrs["arc_firmware_version"] = "1.6"
-    events_create(ac, asset_id, props, attrs, asset_attrs=asset_attrs)
+    events_create(
+        ac,
+        asset_id,
+        props,
+        attrs,
+        asset_attrs=asset_attrs,
+        confirm=True,
+    )
 
     # -> All is well
     LOGGER.info("Done")

--- a/archivist_samples/synsation/locations/__init__.py
+++ b/archivist_samples/synsation/locations/__init__.py
@@ -1,0 +1,2 @@
+"""For pkg_resources of importing data files
+"""

--- a/archivist_samples/synsation/synsation_corporation.py
+++ b/archivist_samples/synsation/synsation_corporation.py
@@ -21,35 +21,37 @@ import random
 import time
 
 from ..testing.namespace import (
-    locations_create_from_yaml_file,
+    assets_create_if_not_exists,
 )
 
 from .util import (
-    assets_create_if_not_exists,
-    attachments_read_from_file,
+    asset_attachment_upload_from_file,
+    locations_create_from_yaml_file,
 )
 
 LOGGER = logging.getLogger(__name__)
-
-LOCATIONS_DIR = "archivist_samples/synsation/locations"
 
 
 def initialise_asset_types(ac, timedelay):
     type_map = {}
 
-    newattachment = attachments_read_from_file(
-        ac, "assets/multifunction_printer.jpg", "image/jpg"
+    newattachment = asset_attachment_upload_from_file(
+        ac, "multifunction_printer.jpg", "image/jpg"
     )
     type_map["Multifunction Printer"] = newattachment
     time.sleep(timedelay)
 
-    newattachment = attachments_read_from_file(
-        ac, "assets/coffee_machine.jpg", "image/jpg"
+    newattachment = asset_attachment_upload_from_file(
+        ac, "coffee_machine.jpg", "image/jpg"
     )
     type_map["Connected Coffee Machine"] = newattachment
     time.sleep(timedelay)
 
-    newattachment = attachments_read_from_file(ac, "assets/black_cctv.jpg", "image/jpg")
+    newattachment = asset_attachment_upload_from_file(
+        ac,
+        "black_cctv.jpg",
+        "image/jpg",
+    )
     type_map["Security Camera"] = newattachment
     time.sleep(timedelay)
 
@@ -61,23 +63,23 @@ def initialise_asset_types(ac, timedelay):
 def create_locations(ac, timedelay):
     corporation_locations = {}
 
-    newlocation = locations_create_from_yaml_file(ac, f"{LOCATIONS_DIR}/grayslake.yaml")
+    newlocation = locations_create_from_yaml_file(ac, "grayslake.yaml")
     corporation_locations[newlocation["display_name"]] = newlocation["identity"]
     time.sleep(timedelay)
 
-    newlocation = locations_create_from_yaml_file(ac, f"{LOCATIONS_DIR}/baltimore.yaml")
+    newlocation = locations_create_from_yaml_file(ac, "baltimore.yaml")
     corporation_locations[newlocation["display_name"]] = newlocation["identity"]
     time.sleep(timedelay)
 
-    newlocation = locations_create_from_yaml_file(ac, f"{LOCATIONS_DIR}/european.yaml")
+    newlocation = locations_create_from_yaml_file(ac, "european.yaml")
     corporation_locations[newlocation["display_name"]] = newlocation["identity"]
     time.sleep(timedelay)
 
-    newlocation = locations_create_from_yaml_file(ac, f"{LOCATIONS_DIR}/asia.yaml")
+    newlocation = locations_create_from_yaml_file(ac, "asia.yaml")
     corporation_locations[newlocation["display_name"]] = newlocation["identity"]
     time.sleep(timedelay)
 
-    newlocation = locations_create_from_yaml_file(ac, f"{LOCATIONS_DIR}/za.yaml")
+    newlocation = locations_create_from_yaml_file(ac, "za.yaml")
     corporation_locations[newlocation["display_name"]] = newlocation["identity"]
     time.sleep(timedelay)
 

--- a/archivist_samples/synsation/synsation_industries.py
+++ b/archivist_samples/synsation/synsation_industries.py
@@ -24,7 +24,9 @@ import logging
 import random
 import string
 
-from .util import assets_create_if_not_exists, attachments_read_from_file
+from ..testing.namespace import assets_create_if_not_exists
+
+from .util import asset_attachment_upload_from_file
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,13 +34,13 @@ LOGGER = logging.getLogger(__name__)
 def initialise_asset_types(ac):
     type_map = {}
 
-    newattachment = attachments_read_from_file(
-        ac, "assets/small_ev_charger.jpg", "image/jpg"
+    newattachment = asset_attachment_upload_from_file(
+        ac, "small_ev_charger.jpg", "image/jpg"
     )
     type_map["Small EV Charger"] = newattachment
 
-    newattachment = attachments_read_from_file(
-        ac, "assets/large_ev_charger.jpg", "image/jpg"
+    newattachment = asset_attachment_upload_from_file(
+        ac, "large_ev_charger.jpg", "image/jpg"
     )
     type_map["Large EV Charger"] = newattachment
 

--- a/archivist_samples/synsation/synsation_manufacturing.py
+++ b/archivist_samples/synsation/synsation_manufacturing.py
@@ -21,13 +21,19 @@ import string
 import random
 import time
 
-from .util import assets_create_if_not_exists, attachments_read_from_file
+from ..testing.namespace import assets_create_if_not_exists
+
+from .util import asset_attachment_upload_from_file
 
 
 def initialise_asset_types(ac):
     type_map = {}
 
-    newattachment = attachments_read_from_file(ac, "assets/crate.jpg", "image/jpg")
+    newattachment = asset_attachment_upload_from_file(
+        ac,
+        "crate.jpg",
+        "image/jpg",
+    )
     type_map["Shipping Crate"] = newattachment
 
     return type_map

--- a/archivist_samples/synsation/synsation_smartcity.py
+++ b/archivist_samples/synsation/synsation_smartcity.py
@@ -18,7 +18,9 @@
 
 import logging
 
-from .util import assets_create_if_not_exists, attachments_read_from_file
+from ..testing.namespace import assets_create_if_not_exists
+
+from .util import asset_attachment_upload_from_file
 
 LOGGER = logging.getLogger(__name__)
 
@@ -26,28 +28,28 @@ LOGGER = logging.getLogger(__name__)
 def initialise_asset_types(ac):
     type_map = {}
 
-    newattachment = attachments_read_from_file(
-        ac, "assets/outdoor_cctv.jpg", "image/jpg"
+    newattachment = asset_attachment_upload_from_file(
+        ac, "outdoor_cctv.jpg", "image/jpg"
     )
     type_map["Outdoor security camera"] = newattachment
 
-    newattachment = attachments_read_from_file(
-        ac, "assets/traffic_light_with_violation_camera.jpg", "image/jpg"
+    newattachment = asset_attachment_upload_from_file(
+        ac, "traffic_light_with_violation_camera.jpg", "image/jpg"
     )
     type_map["Traffic light with violation camera"] = newattachment
 
-    newattachment = attachments_read_from_file(
-        ac, "assets/traffic_light.jpg", "image/jpg"
+    newattachment = asset_attachment_upload_from_file(
+        ac, "traffic_light.jpg", "image/jpg"
     )
     type_map["Traffic light"] = newattachment
 
-    newattachment = attachments_read_from_file(
-        ac, "assets/street_light_controller.jpg", "image/jpg"
+    newattachment = asset_attachment_upload_from_file(
+        ac, "street_light_controller.jpg", "image/jpg"
     )
     type_map["Street light controller"] = newattachment
 
-    newattachment = attachments_read_from_file(
-        ac, "assets/outdoor_air_quality_meter.jpg", "image/jpg"
+    newattachment = asset_attachment_upload_from_file(
+        ac, "outdoor_air_quality_meter.jpg", "image/jpg"
     )
     type_map["Outdoor air quality meter"] = newattachment
 

--- a/archivist_samples/synsation/util.py
+++ b/archivist_samples/synsation/util.py
@@ -18,13 +18,48 @@
 
 # pylint:  disable=missing-docstring
 
-from archivist.errors import ArchivistNotFoundError
+try:
+    import importlib.resources as pkg_resources
+except ImportError:
+    # Try backported to PY<37 `importlib_resources`.
+    import importlib_resources as pkg_resources
+
+from yaml import full_load
+
+from . import images, locations
+from .images import assets as images_assets
 
 from ..testing.namespace import (
-    assets_create,
-    assets_read_by_signature,
-    attachments_upload_from_file,
+    locations_create_if_not_exists,
 )
+
+
+# NB: this is not namespaced and cannot be namespaced until we get GRP2.0
+#     and a proto definition with suitable attributes
+def asset_attachment_upload_from_file(arch, name, mtype):
+    with pkg_resources.open_binary(images_assets, name) as fd:
+        attachment = arch.attachments.upload(fd, mtype=mtype)
+
+    return attachment
+
+
+def attachment_upload_from_file(arch, name, mtype):
+    with pkg_resources.open_binary(images, name) as fd:
+        attachment = arch.attachments.upload(fd, mtype=mtype)
+
+    return attachment
+
+
+def locations_create_from_yaml_file(arch, name):
+    """Load location from yaml file
+
+    assumes there is only one document in the file.
+    """
+    with pkg_resources.open_binary(locations, name) as fd:
+        data = full_load(fd)
+        attrs = data["attributes"]
+        del data["attributes"]
+        return locations_create_if_not_exists(arch, data, attrs=attrs)
 
 
 def make_event_json(
@@ -47,24 +82,3 @@ def make_event_json(
         "arc_correlation_value": corval,
     }
     return props, attrs
-
-
-def attachments_read_from_file(arch, name, mtype):
-    return attachments_upload_from_file(
-        arch, f"archivist_samples/synsation/images/{name}", mtype
-    )
-
-
-def assets_create_if_not_exists(arch, behaviours, attrs, *, confirm=None):
-    asset = None
-    try:
-        asset = assets_read_by_signature(
-            arch,
-            {
-                "arc_display_name": attrs["arc_display_name"],
-            },
-        )
-    except ArchivistNotFoundError:
-        asset = assets_create(arch, behaviours, attrs, confirm=confirm)
-
-    return asset

--- a/archivist_samples/synsation/wanderer.py
+++ b/archivist_samples/synsation/wanderer.py
@@ -44,9 +44,7 @@ from .util import make_event_json
 #####################
 
 
-def make_event_json_template(
-    unused_asset_identity, what_str, who_str, message, lat, lng, tw
-):
+def make_event_json_template(what_str, who_str, message, lat, lng, tw):
     notnow = tw.now()
     dtstring = make_timestamp(notnow)
     props, attrs = make_event_json(
@@ -76,7 +74,6 @@ def shipit(ac, crate_id, delay, tw):
 
     LOGGER.info(f"Asset starting its journey at {start[0]}")
     props, attrs = make_event_json_template(
-        crate_id,
         "Shipping Movement",
         who_str,
         f"Crate sealed in {start[0]} with 448 units on board",
@@ -84,13 +81,12 @@ def shipit(ac, crate_id, delay, tw):
         start[2],
         tw,
     )
-    events_create(ac, crate_id, props, attrs)
+    events_create(ac, crate_id, props, attrs, confirm=True)
     time.sleep(delay)
 
     for point in waypoints:
         LOGGER.info(f"Asset arriving at {point[0]}")
         props, attrs = make_event_json_template(
-            crate_id,
             "Shipping Movement",
             who_str,
             f"Crate transferred by shipping agent at {point[0]} for onward forwarding",
@@ -98,12 +94,11 @@ def shipit(ac, crate_id, delay, tw):
             point[2],
             tw,
         )
-        events_create(ac, crate_id, props, attrs)
+        events_create(ac, crate_id, props, attrs, confirm=True)
         time.sleep(delay)
 
     LOGGER.info(f"Asset ending its journey at {end[0]}")
     props, attrs = make_event_json_template(
-        crate_id,
         "Shipping Movement",
         who_str,
         f"Crate unsealed in {end[0]} with 448 units on board",
@@ -111,7 +106,7 @@ def shipit(ac, crate_id, delay, tw):
         end[2],
         tw,
     )
-    events_create(ac, crate_id, props, attrs)
+    events_create(ac, crate_id, props, attrs, confirm=True)
 
 
 def run(ac, args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cryptography==3.3.2
+importlib_resources==5.2.0 ; python_version == '3.6'
 jitsuin-archivist==0.2.0a2
 pyyaml==5.4.1

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     long_description_content_type="text/markdown",
     url=REPO_URL,
     packages=find_packages(exclude=( "examples", "unittests", )),
+    include_package_data=True,
     platforms=['any'],
     classifiers=[
         'Development Status :: 3 - Alpha', #pre-delivery


### PR DESCRIPTION
Problem:
The internal tests will not run without internal images and other files.

Solution:
Added data files to wheel package and used pkg_resources to read them in
the internal code.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>