### PR TITLE
Make_event_json factory function unnecessary.

### DIFF
--- a/archivist_samples/door_entry/run.py
+++ b/archivist_samples/door_entry/run.py
@@ -48,9 +48,6 @@ DOOR_CARD = "Door entry card"
 
 BEHAVIOURS = [
     "Attachments",
-    "Firmware",
-    "LocationUpdate",
-    "Maintenance",
     "RecordEvidence",
 ]
 

--- a/archivist_samples/synsation/maintenance_worker.py
+++ b/archivist_samples/synsation/maintenance_worker.py
@@ -21,9 +21,7 @@ import logging
 import random
 import time
 
-from archivist.timestamp import make_timestamp
-
-from .util import make_event_json
+from ..testing.asset import MyAsset
 
 LOGGER = logging.getLogger(__name__)
 
@@ -35,24 +33,18 @@ def service_device(charger, job_id, timewarp):
     LOGGER.info("!! Agent responding to service request on %s", charger.name)
 
     # The maintenance is done...inform Archivist
-    maint_msg = (
-        f"Maintenance agent serviced device after "
-        f"{charger.total_charge} units charged.  Next service "
-        f"at {charger.next_service}."
-    )
-    notnow = timewarp.now()
-    dtstring = make_timestamp(notnow)
-    props, attrs = make_event_json(
-        "Maintenance",
-        "Maintenance",
-        dtstring,
+    MyAsset(
+        charger.archivist_client,
+        charger.archivist_identity,
+        timewarp,
         "Phil@evcservicing.com",
-        "Service RP",
-        maint_msg,
+    ).service(
+        (
+            f"Maintenance agent serviced device after "
+            f"{charger.total_charge} units charged.  Next service "
+            f"at {charger.next_service}."
+        ),
         job_id,
-    )
-    charger.archivist_client.events.create(
-        charger.archivist_asset_identity, props, attrs
     )
 
 

--- a/archivist_samples/synsation/synsation_corporation.py
+++ b/archivist_samples/synsation/synsation_corporation.py
@@ -123,9 +123,6 @@ def create_assets(ac, asset_types, locations, num_assets, timedelay):
         }
         behaviours = [
             "Attachments",
-            "Firmware",
-            "LocationUpdate",
-            "Maintenance",
             "RecordEvidence",
         ]
         newasset = assets_create_if_not_exists(ac, behaviours, attrs)

--- a/archivist_samples/synsation/synsation_industries.py
+++ b/archivist_samples/synsation/synsation_industries.py
@@ -82,9 +82,6 @@ def make_charger_asset(
     }
     behaviours = [
         "Attachments",
-        "Firmware",
-        "LocationUpdate",
-        "Maintenance",
         "RecordEvidence",
     ]
     newasset = assets_create_if_not_exists(ac, behaviours, attrs)

--- a/archivist_samples/synsation/synsation_manufacturing.py
+++ b/archivist_samples/synsation/synsation_manufacturing.py
@@ -105,9 +105,6 @@ def create_shipping_crate(
     }
     behaviours = [
         "Attachments",
-        "Firmware",
-        "LocationUpdate",
-        "Maintenance",
         "RecordEvidence",
     ]
     newasset = assets_create_if_not_exists(ac, behaviours, attrs)

--- a/archivist_samples/synsation/synsation_smartcity.py
+++ b/archivist_samples/synsation/synsation_smartcity.py
@@ -79,9 +79,6 @@ def create_smartcity_device(
     }
     behaviours = [
         "Attachments",
-        "Firmware",
-        "LocationUpdate",
-        "Maintenance",
         "RecordEvidence",
     ]
     newasset = assets_create_if_not_exists(ac, behaviours, attrs)

--- a/archivist_samples/synsation/util.py
+++ b/archivist_samples/synsation/util.py
@@ -60,25 +60,3 @@ def locations_create_from_yaml_file(arch, name):
         attrs = data["attributes"]
         del data["attributes"]
         return locations_create_if_not_exists(arch, data, attrs=attrs)
-
-
-def make_event_json(
-    event_behaviour, event_op, when_str, who_str, what_str, msg_str, corval
-):
-    """Create a simple Archivist event payload"""
-    props = {
-        "operation": event_op,
-        "behaviour": event_behaviour,
-        "principal_declared": {
-            "issuer": "job.idp.server/1234",
-            "subject": who_str,
-            "display_name": who_str,
-        },
-        "timestamp_declared": when_str,
-    }
-    attrs = {
-        "arc_display_type": what_str,
-        "arc_description": msg_str,
-        "arc_correlation_value": corval,
-    }
-    return props, attrs

--- a/archivist_samples/testing/asset.py
+++ b/archivist_samples/testing/asset.py
@@ -1,0 +1,215 @@
+#   Copyright 2019 Jitsuin, inc
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# WARNING: Proof of concept code: Not for release
+# Copies the flow of the Jitsuinator demo script
+
+"""Class that implements common actions on an asset. This is the secret sauce
+   and this code may be added to the python SDK at some later date...
+"""
+
+# pylint:  disable=missing-docstring
+
+from archivist.timestamp import make_timestamp
+
+from .namespace import (
+    events_create,
+)
+
+CONFIG_MANAGEMENT = "Config Management"
+OPERATIONAL_REPORT = "Operational Report"
+MAINTENANCE_PERFORMED = "Maintenance Performed"
+MAINTENANCE_REQUEST = "Maintenance Request"
+SHIPPING_MOVEMENT = "Shipping Movement"
+VULNERABILITY_ADDRESSED = "Vulnerability Addressed"
+VULNERABILITY_REPORT = "Vulnerability Report"
+
+
+class MyAsset:
+    def __init__(self, ac, crate_id, tw, who):
+        self.ac = ac
+        self.crate_id = crate_id
+        self.tw = tw
+        self.base_props = {
+            "behaviour": "RecordEvidence",
+            "operation": "Record",
+            "principal_declared": {
+                "issuer": "job.idp.server/1234",
+                "subject": who,
+                "display_name": who,
+            },
+        }
+
+    def charge(self, desc, evidence):
+        """Charge device"""
+        events_create(
+            self.ac,
+            self.crate_id,
+            {
+                **self.base_props,
+                **{
+                    "timestamp_declared": make_timestamp(self.tw.now()),
+                },
+            },
+            {
+                "arc_display_type": OPERATIONAL_REPORT,
+                "arc_description": desc,
+                "arc_evidence": evidence,
+            },
+            confirm=True,
+        )
+
+    def certify_patch(self, desc, evidence, attachments, extra_attrs=None):
+        """Certify issued patch"""
+        attrs = {
+            **{
+                "arc_display_type": CONFIG_MANAGEMENT,
+                "arc_description": desc,
+                "arc_evidence": evidence,
+            },
+            **attachments,
+        }
+        if extra_attrs is not None:
+            attrs.update(extra_attrs)
+
+        events_create(
+            self.ac,
+            self.crate_id,
+            {
+                **self.base_props,
+                **{
+                    "timestamp_declared": make_timestamp(self.tw.now()),
+                },
+            },
+            attrs,
+            confirm=True,
+        )
+
+    def move(self, desc, lat, lng):
+        """Move asset from one place to another"""
+        events_create(
+            self.ac,
+            self.crate_id,
+            {
+                **self.base_props,
+                **{
+                    "timestamp_declared": make_timestamp(self.tw.now()),
+                },
+            },
+            {
+                "arc_display_type": SHIPPING_MOVEMENT,
+                "arc_description": desc,
+                "arc_gis_lat": lat,
+                "arc_gis_lng": lng,
+            },
+            confirm=True,
+        )
+
+    def patch_vulnerability(self, desc, evidence):
+        """Patch  vulnerability"""
+        events_create(
+            self.ac,
+            self.crate_id,
+            {
+                **self.base_props,
+                **{
+                    "timestamp_declared": make_timestamp(self.tw.now()),
+                },
+            },
+            {
+                "arc_display_type": CONFIG_MANAGEMENT,
+                "arc_description": desc,
+                "arc_evidence": evidence,
+            },
+            confirm=True,
+        )
+
+    def report_vulnerability(self, desc, cve_id, cve_corval):
+        """Report vulnerability"""
+        events_create(
+            self.ac,
+            self.crate_id,
+            {
+                **self.base_props,
+                **{
+                    "timestamp_declared": make_timestamp(self.tw.now()),
+                },
+            },
+            {
+                "arc_display_type": VULNERABILITY_REPORT,
+                "arc_description": desc,
+                "arc_cve_id": cve_id,
+                "arc_correlation_value": cve_corval,
+            },
+            confirm=True,
+        )
+
+    def service_required(self, desc, corval):
+        """Indicate that maintenance must been done"""
+        events_create(
+            self.ac,
+            self.crate_id,
+            {
+                **self.base_props,
+                **{
+                    "timestamp_declared": make_timestamp(self.tw.now()),
+                },
+            },
+            {
+                "arc_display_type": MAINTENANCE_REQUEST,
+                "arc_description": desc,
+                "arc_correlation_value": corval,
+            },
+            confirm=True,
+        )
+
+    def service(self, desc, corval):
+        """Indicate that maintenance has been done"""
+        events_create(
+            self.ac,
+            self.crate_id,
+            {
+                **self.base_props,
+                **{
+                    "timestamp_declared": make_timestamp(self.tw.now()),
+                },
+            },
+            {
+                "arc_display_type": MAINTENANCE_PERFORMED,
+                "arc_description": desc,
+                "arc_correlation_value": corval,
+            },
+            confirm=True,
+        )
+
+    def update_firmware(self, desc, fw_version, corval):
+        """Update firmware"""
+        events_create(
+            self.ac,
+            self.crate_id,
+            {
+                **self.base_props,
+                **{
+                    "timestamp_declared": make_timestamp(self.tw.now()),
+                },
+            },
+            {
+                "arc_display_type": VULNERABILITY_ADDRESSED,
+                "arc_description": desc,
+                "arc_firmware_version": fw_version,
+                "arc_correlation_value": corval,
+            },
+            asset_attrs={"arc_firmware_version": fw_version},
+            confirm=True,
+        )


### PR DESCRIPTION
Problem:
The make_event_json factory function serves no puprose except to make
reuse difficult.

Solution:
Replace with MyAsset class with methods that reflect user's expected
use cases such as 'update_firmware' etc....
Additionally make all events use Recordevidence' behaviour.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>