### PR TITLE
Use storage integrity for SBOM

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -36,12 +36,15 @@ specify the archivist endpoint:
 
 ```bash
 export TEST_ARCHIVIST="https://rkvst.poc.jitsuin.io"
-export TEST_AUTHTOKEN=credentials/.auth_token
+export TEST_AUTHTOKEN_FILENAME=credentials/.auth_token
 export TEST_NAMESPACE="unique label"
 export TEST_VERBOSE=-v
+export TEST_STORAGE_INTEGRITY="--storage-integrity TENANT_STORAGE"
 ```
 
 If TEST_VERBOSE is "-v" debugging output will appear when running the tests.
+
+TEST_STORAGE_INTEGRITY must be either "LEDGER" or "TENANT_STORAGE"
 
 ## TEST_NAMESPACE
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,15 @@ specify the archivist endpoint:
 
 ```bash
 export ARCHIVIST="https://rkvst.poc.jitsuin.io"
-export AUTHTOKEN=credentials/.auth_token
+export AUTHTOKEN_FILENAME=credentials/.auth_token
 export NAMESPACE="unique label"
 export VERBOSE=-v
+export STORAGE_INTEGRITY="--storage-integrity=TENANT_STORAGE"
 ```
 
 If VERBOSE is "-v" debugging output will appear when running the examples. Otherwise leave blank or undefined.
+
+STORAGE_INTEGRITY should be "LEDGER" or "TENANT_STORAGE". If unspecified the default is "TENANT_STORAGE"
 
 ## NAMESPACE
 
@@ -55,7 +58,7 @@ Events are created every execution of an example - currently no check is done if
 All examples use a common set of arguments:
 
 ```bash
-export AUTH="-u $ARCHIVIST -t $AUTHTOKEN $VERBOSE"
+export AUTH="-u $ARCHIVIST -t $AUTHTOKEN_FILENAME $VERBOSE $STORAGE_INTEGRITY"
 export ARGS="$AUTH --namespace $NAMESPACE"
 ```
 

--- a/archivist_samples/door_entry/main.py
+++ b/archivist_samples/door_entry/main.py
@@ -17,38 +17,19 @@
 # pylint:  disable=missing-docstring
 
 
-import argparse
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
 from archivist.archivist import Archivist
 
 from ..testing.logger import set_logger, LOGGER
+from ..testing.parser import common_parser
 
 from .run import run
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Exercises the various Wavestone door entry use cases"
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        dest="verbose",
-        action="store_true",
-        default=False,
-        help="print verbose debugging",
-    )
-    parser.add_argument(
-        "-u",
-        "--url",
-        type=str,
-        dest="url",
-        action="store",
-        default="https://rkvst.poc.jitsuin.io",
-        help="location of Archivist service",
-    )
+    parser, _ = common_parser("Exercises the various Wavestone door entry use cases")
     parser.add_argument(
         "--namespace",
         type=str,
@@ -56,28 +37,6 @@ def main():
         action="store",
         default=None,
         help="namespace of item population (to enable parallel demos",
-    )
-
-    security = parser.add_mutually_exclusive_group(required=True)
-    security.add_argument(
-        "-t",
-        "--auth-token",
-        type=str,
-        dest="auth_token_file",
-        action="store",
-        default=".auth_token",
-        help="FILE containing API authentication token",
-    )
-    security.add_argument(
-        "-c",
-        "--clientcert",
-        type=str,
-        dest="client_cert_name",
-        action="store",
-        help=(
-            "name of TLS client cert (.key and .pem with matching name must"
-            "be in current directory)"
-        ),
     )
 
     parser.add_argument(
@@ -145,6 +104,7 @@ def main():
     poc.namespace = (
         "_".join(["door_entry", args.namespace]) if args.namespace is not None else None
     )
+    poc.storage_integrity = args.storage_integrity
 
     run(poc, args)
 

--- a/archivist_samples/estate_info/main.py
+++ b/archivist_samples/estate_info/main.py
@@ -19,7 +19,6 @@
 # pylint:  disable=missing-docstring
 
 
-import argparse
 from collections import Counter
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
@@ -28,6 +27,7 @@ from archivist import about
 from archivist.archivist import Archivist
 
 from ..testing.logger import set_logger, LOGGER
+from ..testing.parser import common_parser
 
 # Main app
 ##########
@@ -95,24 +95,7 @@ def run(poc, args):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Some title")
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        dest="verbose",
-        action="store_true",
-        default=False,
-        help="print verbose debugging",
-    )
-    parser.add_argument(
-        "-u",
-        "--url",
-        type=str,
-        dest="url",
-        action="store",
-        default="https://rkvst.poc.jitsuin.io",
-        help="location of Archivist service",
-    )
+    parser, _ = common_parser("Get basic information about your RKVST estate")
     parser.add_argument(
         "--namespace",
         type=str,
@@ -123,28 +106,6 @@ def main():
     )
 
     # per example options here
-
-    security = parser.add_mutually_exclusive_group(required=True)
-    security.add_argument(
-        "-t",
-        "--auth-token",
-        type=str,
-        dest="auth_token_file",
-        action="store",
-        default=".auth_token",
-        help="FILE containing API authentication token",
-    )
-    security.add_argument(
-        "-c",
-        "--clientcert",
-        type=str,
-        dest="client_cert_name",
-        action="store",
-        help=(
-            "name of TLS client cert (.key and .pem with matching name"
-            "must be in current directory)"
-        ),
-    )
 
     # per example exclusive options here
     operations = parser.add_mutually_exclusive_group(required=True)
@@ -188,6 +149,7 @@ def main():
         sys_exit(1)
 
     poc.namespace = None  # ignore namespacing for the time being
+    poc.storage_integrity = args.storage_integrity
 
     run(poc, args)
 

--- a/archivist_samples/signed_records/main.py
+++ b/archivist_samples/signed_records/main.py
@@ -20,7 +20,6 @@
 # pylint:  disable=missing-docstring
 
 
-import argparse
 import base64
 import os
 
@@ -50,6 +49,7 @@ from ..testing.namespace import (
     events_create,
     events_list,
 )
+from ..testing.parser import common_parser
 
 # Key management functions
 #
@@ -394,27 +394,8 @@ def run(archivist, args):
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description=(
-            "Shows simple integration of a device private signing key with Archivist records"
-        )
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        dest="verbose",
-        action="store_true",
-        default=False,
-        help="print verbose debugging",
-    )
-    parser.add_argument(
-        "-u",
-        "--url",
-        type=str,
-        dest="url",
-        action="store",
-        default="https://rkvst.poc.jitsuin.io",
-        help="location of Archivist service",
+    parser, _ = common_parser(
+        "Shows simple integration of a device private signing key with Archivist records"
     )
     parser.add_argument(
         "--namespace",
@@ -423,28 +404,6 @@ def main():
         action="store",
         default=None,
         help="namespace of item population (to enable parallel demos",
-    )
-
-    security = parser.add_mutually_exclusive_group(required=True)
-    security.add_argument(
-        "-t",
-        "--auth-token",
-        type=str,
-        dest="auth_token_file",
-        action="store",
-        default=".auth_token",
-        help="FILE containing API authentication token",
-    )
-    security.add_argument(
-        "-c",
-        "--clientcert",
-        type=str,
-        dest="client_cert_name",
-        action="store",
-        help=(
-            "name of TLS client cert (.key and .pem with matching name"
-            "must be in current directory)"
-        ),
     )
 
     # Operations
@@ -510,6 +469,7 @@ def main():
         if args.namespace is not None
         else None
     )
+    poc.storage_integrity = args.storage_integrity
 
     run(poc, args)
 

--- a/archivist_samples/software_bill_of_materials/main.py
+++ b/archivist_samples/software_bill_of_materials/main.py
@@ -17,37 +17,20 @@
 # pylint:  disable=missing-docstring
 
 
-import argparse
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
 from archivist.archivist import Archivist
 
 from ..testing.logger import set_logger, LOGGER
+from ..testing.parser import common_parser
 
 from .run import run
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Exercises the various Wavestone door entry use cases"
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        dest="verbose",
-        action="store_true",
-        default=False,
-        help="print verbose debugging",
-    )
-    parser.add_argument(
-        "-u",
-        "--url",
-        type=str,
-        dest="url",
-        action="store",
-        default="https://rkvst.poc.jitsuin.io",
-        help="location of Archivist service",
+    parser, _ = common_parser(
+        "Simple SBOM implementation that conforms with NTIA recommendations"
     )
     parser.add_argument(
         "--namespace",
@@ -56,28 +39,6 @@ def main():
         action="store",
         default=None,
         help="namespace of item population (to enable parallel demos",
-    )
-
-    security = parser.add_mutually_exclusive_group(required=True)
-    security.add_argument(
-        "-t",
-        "--auth-token",
-        type=str,
-        dest="auth_token_file",
-        action="store",
-        default=".auth_token",
-        help="FILE containing API authentication token",
-    )
-    security.add_argument(
-        "-c",
-        "--clientcert",
-        type=str,
-        dest="client_cert_name",
-        action="store",
-        help=(
-            "name of TLS client cert (.key and .pem with matching name must"
-            "be in current directory)"
-        ),
     )
 
     args = parser.parse_args()
@@ -103,8 +64,9 @@ def main():
         sys_exit(1)
 
     poc.namespace = (
-        "_".join(["sbom", args.namespace]) if args.namespace is not None else None
+        "_".join(["sbom", args.namespace]) if args.namespace is not None else "sbom"
     )
+    poc.storage_integrity = args.storage_integrity
 
     run(poc)
 

--- a/archivist_samples/software_bill_of_materials/run.py
+++ b/archivist_samples/software_bill_of_materials/run.py
@@ -23,6 +23,7 @@ except ImportError:
     import importlib_resources as pkg_resources
 
 import logging
+from sys import exit as sys_exit
 
 from archivist import about
 
@@ -52,7 +53,7 @@ def run(arch):
 
     # SoftwarePackage class encapsulates SBOM object in RKVST
     LOGGER.info("Creating Software Package Asset...")
-    package = SoftwarePackage(arch)
+    package = SoftwarePackage(arch, storage_integrity=arch.storage_integrity)
 
     package.create(
         "ACME Roadrunner Detector 2013 Coyote Edition SP1",
@@ -65,8 +66,7 @@ def run(arch):
     )
     LOGGER.info("Software Package Created (Identity=%s)", package.asset["identity"])
 
-    # Make a release
-    LOGGER.info("Making a release...")
+    LOGGER.info("1 Making a release...")
     package.release(
         {
             "name": "ACME Roadrunner Detector 2013 Coyote Edition SP1",
@@ -81,8 +81,7 @@ def run(arch):
     )
     LOGGER.info("Release registered.")
 
-    # Make a release
-    LOGGER.info("Making a release...")
+    LOGGER.info("2 Making a release...")
     package.release(
         {
             "name": "ACME Roadrunner Detector 2013 Coyote Edition SP1",
@@ -97,8 +96,7 @@ def run(arch):
     )
     LOGGER.info("Release registered.")
 
-    # Private patch
-    LOGGER.info("Making a private patch...")
+    LOGGER.info("3 Making a private patch...")
     package.private_patch(
         {
             "private_id": "special_customer",
@@ -116,8 +114,7 @@ def run(arch):
     )
     LOGGER.info("Private patch registered.")
 
-    # Make a release
-    LOGGER.info("Making a release...")
+    LOGGER.info("4 Making a release...")
     package.release(
         {
             "name": "ACME Roadrunner Detector 2013 Coyote Edition SP1",
@@ -132,7 +129,7 @@ def run(arch):
     )
     LOGGER.info("Release registered.")
 
-    # Plan major upgrade
+    LOGGER.info("5 Plan major upgrade...")
     package.release_plan(
         {
             "name": "ACME Roadrunner Detector 2013 Coyote Edition SP1",
@@ -146,7 +143,7 @@ def run(arch):
         attachments=[upload_attachment(arch, "v5_0_0_sbom.xml", "SWID SBOM")],
     )
 
-    # Approve major upgrade
+    LOGGER.info("6 Approve major upgrade...")
     package.release_accepted(
         {
             "name": "ACME Roadrunner Detector 2013 Coyote Edition SP1",
@@ -161,8 +158,7 @@ def run(arch):
         attachments=[upload_attachment(arch, "v5_0_0_sbom.xml", "SWID SBOM")],
     )
 
-    # Release major upgrade
-    LOGGER.info("Making a release...")
+    LOGGER.info("7 Release major upgrade...")
     package.release(
         {
             "name": "ACME Roadrunner Detector 2013 Coyote Edition SP1",
@@ -176,3 +172,4 @@ def run(arch):
         attachments=[upload_attachment(arch, "v5_0_0_sbom.xml", "SWID SBOM")],
     )
     LOGGER.info("Release registered.")
+    sys_exit(0)

--- a/archivist_samples/software_bill_of_materials/software_deployment.py
+++ b/archivist_samples/software_bill_of_materials/software_deployment.py
@@ -7,13 +7,20 @@ from typing import Optional
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
 
 from archivist import archivist as type_helper
+from archivist.storage_integrity import StorageIntegrity
 
 
 class SoftwareDeployment:
-    def __init__(self, arch: "type_helper.Archivist"):
+    def __init__(
+        self,
+        arch: "type_helper.Archivist",
+        *,
+        storage_integrity=StorageIntegrity.TENANT_STORAGE,
+    ):
         self._arch = arch
         self._asset = None
         self._attachments = None
+        self._storage_integrity = storage_integrity
         self._environment = None
 
     @property
@@ -31,6 +38,10 @@ class SoftwareDeployment:
     @property
     def environment(self):
         return self._environment
+
+    @property
+    def storage_integrity(self):
+        return self._storage_integrity
 
     # Create Software Deployment
 
@@ -74,7 +85,9 @@ class SoftwareDeployment:
             "RecordEvidence",
         ]
 
-        self._asset = self.arch.assets.create(behaviours, attrs, confirm=True)
+        self._asset = self.arch.assets.create(
+            behaviours, attrs, storage_integrity=self._storage_integrity, confirm=True
+        )
         return self._asset
 
     # Installation Event

--- a/archivist_samples/software_bill_of_materials/software_package.py
+++ b/archivist_samples/software_bill_of_materials/software_package.py
@@ -8,12 +8,19 @@ from typing import Optional
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
 
 from archivist import archivist as type_helper
+from archivist.storage_integrity import StorageIntegrity
 
 
 class SoftwarePackage:
-    def __init__(self, arch: "type_helper.Archivist"):
+    def __init__(
+        self,
+        arch: "type_helper.Archivist",
+        *,
+        storage_integrity=StorageIntegrity.TENANT_STORAGE,
+    ):
         self._arch = arch
         self._asset = None
+        self._storage_integrity = storage_integrity
 
     @property
     def arch(self):
@@ -22,6 +29,10 @@ class SoftwarePackage:
     @property
     def asset(self):
         return self._asset
+
+    @property
+    def storage_integrity(self):
+        return self._storage_integrity
 
     # Asset Creation
     def create(
@@ -46,7 +57,9 @@ class SoftwarePackage:
             "Attachments",
             "RecordEvidence",
         ]
-        self._asset = self.arch.assets.create(behaviours, attrs, confirm=True)
+        self._asset = self.arch.assets.create(
+            behaviours, attrs, storage_integrity=self._storage_integrity, confirm=True
+        )
         return self._asset
 
     # Asset load by unique identity

--- a/archivist_samples/synsation/analyze.py
+++ b/archivist_samples/synsation/analyze.py
@@ -19,7 +19,6 @@
 # pylint: disable=logging-fstring-interpolation
 
 
-import argparse
 from datetime import datetime, timezone
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
@@ -41,6 +40,7 @@ from ..testing.namespace import (
     events_count,
     events_list,
 )
+from ..testing.parser import common_parser
 
 
 def analyze_matched_pairs(label, p1, p2, events):
@@ -149,26 +149,7 @@ def run(archivist):
 
 
 def entry():
-    parser = argparse.ArgumentParser(
-        description="Checks maintenance and update performance for assets"
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        dest="verbose",
-        action="store_true",
-        default=False,
-        help="print verbose debugging",
-    )
-    parser.add_argument(
-        "-u",
-        "--url",
-        type=str,
-        dest="url",
-        action="store",
-        default="https://rkvst.poc.jitsuin.io",
-        help="location of Archivist service",
-    )
+    parser, _ = common_parser("Checks maintenance and update performance for assets")
     parser.add_argument(
         "--namespace",
         type=str,
@@ -179,28 +160,6 @@ def entry():
     )
 
     # per example options here ....
-
-    security = parser.add_mutually_exclusive_group(required=True)
-    security.add_argument(
-        "-t",
-        "--auth-token",
-        type=str,
-        dest="auth_token_file",
-        action="store",
-        default=".auth_token",
-        help="FILE containing API authentication token",
-    )
-    security.add_argument(
-        "-c",
-        "--clientcert",
-        type=str,
-        dest="client_cert_name",
-        action="store",
-        help=(
-            "name of TLS client cert (.key and .pem with matching name"
-            "must be in current directory)"
-        ),
-    )
 
     args = parser.parse_args()
 
@@ -227,6 +186,7 @@ def entry():
     poc.namespace = (
         "_".join(["synsation", args.namespace]) if args.namespace is not None else None
     )
+    poc.storage_integrity = args.storage_integrity
 
     run(poc)
 

--- a/archivist_samples/synsation/charger.py
+++ b/archivist_samples/synsation/charger.py
@@ -20,7 +20,6 @@
 # pylint:  disable=fixme
 # pylint:  disable=missing-docstring
 
-import argparse
 import datetime
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
@@ -31,12 +30,13 @@ from archivist import about
 from archivist.archivist import Archivist
 
 from ..testing.logger import set_logger, LOGGER
-from ..testing.time_warp import TimeWarp
 
 from ..testing.namespace import (
     assets_count,
     assets_list,
 )
+from ..testing.parser import common_parser
+from ..testing.time_warp import TimeWarp
 
 from . import ev_charger_device
 from . import device_worker
@@ -141,25 +141,8 @@ def run(ac, args):
 
 
 def entry():
-    parser = argparse.ArgumentParser(
-        description="Simulates usage and maintenance of electric vehicle chargers"
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        dest="verbose",
-        action="store_true",
-        default=False,
-        help="print verbose debugging",
-    )
-    parser.add_argument(
-        "-u",
-        "--url",
-        type=str,
-        dest="url",
-        action="store",
-        default="https://rkvst.poc.jitsuin.io",
-        help="location of Archivist service",
+    parser, _ = common_parser(
+        "Simulates usage and maintenance of electric vehicle chargers"
     )
     parser.add_argument(
         "--namespace",
@@ -216,28 +199,6 @@ def entry():
         help="Fast forward time in event series (default: 1 second = 1 hour)",
     )
 
-    security = parser.add_mutually_exclusive_group(required=True)
-    security.add_argument(
-        "-t",
-        "--auth-token",
-        type=str,
-        dest="auth_token_file",
-        action="store",
-        default=".auth_token",
-        help="FILE containing API authentication token",
-    )
-    security.add_argument(
-        "-c",
-        "--clientcert",
-        type=str,
-        dest="client_cert_name",
-        action="store",
-        help=(
-            "name of TLS client cert (.key and .pem with matching name"
-            "must be in current directory)"
-        ),
-    )
-
     args = parser.parse_args()
 
     if args.verbose:
@@ -263,6 +224,7 @@ def entry():
     poc.namespace = (
         "_".join(["synsation", args.namespace]) if args.namespace is not None else None
     )
+    poc.storage_integrity = args.storage_integrity
 
     run(poc, args)
 

--- a/archivist_samples/synsation/initialise.py
+++ b/archivist_samples/synsation/initialise.py
@@ -19,7 +19,6 @@
 # pylint:  disable=missing-docstring
 
 
-import argparse
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
@@ -28,6 +27,7 @@ from archivist.archivist import Archivist
 
 from ..testing.logger import set_logger, LOGGER
 from ..testing.namespace import assets_wait_for_confirmed
+from ..testing.parser import common_parser
 
 from . import synsation_corporation
 from . import synsation_industries
@@ -62,25 +62,8 @@ def run(ac, args):
 
 
 def entry():
-    parser = argparse.ArgumentParser(
-        description="Populates a clean Archivist with Synsation test data"
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        dest="verbose",
-        action="store_true",
-        default=False,
-        help="print verbose debugging",
-    )
-    parser.add_argument(
-        "-u",
-        "--url",
-        type=str,
-        dest="url",
-        action="store",
-        default="https://rkvst.poc.jitsuin.io",
-        help="location of Archivist service",
+    parser, _ = common_parser(
+        "Populates a clean RKVST tenancy with Synsation test data"
     )
     parser.add_argument(
         "--namespace",
@@ -149,28 +132,6 @@ def entry():
         help="wait for all assets to be confirmed before exit",
     )
 
-    security = parser.add_mutually_exclusive_group(required=True)
-    security.add_argument(
-        "-t",
-        "--auth-token",
-        type=str,
-        dest="auth_token_file",
-        action="store",
-        default=".auth_token",
-        help="FILE containing API authentication token",
-    )
-    security.add_argument(
-        "-c",
-        "--clientcert",
-        type=str,
-        dest="client_cert_name",
-        action="store",
-        help=(
-            "name of TLS client cert (.key and .pem with matching name"
-            "must be in current directory)"
-        ),
-    )
-
     args = parser.parse_args()
 
     if args.verbose:
@@ -196,6 +157,7 @@ def entry():
     poc.namespace = (
         "_".join(["synsation", args.namespace]) if args.namespace is not None else None
     )
+    poc.storage_integrity = args.storage_integrity
 
     run(poc, args)
 

--- a/archivist_samples/synsation/jitsuinator.py
+++ b/archivist_samples/synsation/jitsuinator.py
@@ -21,7 +21,6 @@
 # pylint:  disable=too-many-statements
 
 
-import argparse
 import datetime
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
@@ -32,11 +31,12 @@ from archivist import about
 from archivist.archivist import Archivist
 from archivist.errors import ArchivistNotFoundError
 
+from ..testing.asset import MyAsset
 from ..testing.logger import set_logger, LOGGER
 from ..testing.namespace import (
     assets_read_by_signature,
 )
-from ..testing.asset import MyAsset
+from ..testing.parser import common_parser
 from ..testing.time_warp import TimeWarp
 
 from .util import attachment_upload_from_file
@@ -191,26 +191,7 @@ def run(ac, args):
 
 
 def entry():
-    parser = argparse.ArgumentParser(
-        description="Runs the Jitsuinator demo script manually"
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        dest="verbose",
-        action="store_true",
-        default=False,
-        help="print verbose debugging",
-    )
-    parser.add_argument(
-        "-u",
-        "--url",
-        type=str,
-        dest="url",
-        action="store",
-        default="https://rkvst.poc.jitsuin.io",
-        help="location of Archivist service",
-    )
+    parser, _ = common_parser("Runs the Jitsuinator demo script manually")
     parser.add_argument(
         "--namespace",
         type=str,
@@ -257,28 +238,6 @@ def entry():
         help="auto-advance after WAIT seconds",
     )
 
-    security = parser.add_mutually_exclusive_group(required=True)
-    security.add_argument(
-        "-t",
-        "--auth-token",
-        type=str,
-        dest="auth_token_file",
-        action="store",
-        default=".auth_token",
-        help="FILE containing API authentication token",
-    )
-    security.add_argument(
-        "-c",
-        "--clientcert",
-        type=str,
-        dest="client_cert_name",
-        action="store",
-        help=(
-            "name of TLS client cert (.key and .pem with matching name"
-            "must be in current directory)"
-        ),
-    )
-
     args = parser.parse_args()
 
     if args.verbose:
@@ -304,6 +263,7 @@ def entry():
     poc.namespace = (
         "_".join(["synsation", args.namespace]) if args.namespace is not None else None
     )
+    poc.storage_integrity = args.storage_integrity
 
     run(poc, args)
 

--- a/archivist_samples/synsation/wanderer.py
+++ b/archivist_samples/synsation/wanderer.py
@@ -18,7 +18,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=logging-fstring-interpolation
 
-import argparse
 import datetime
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
@@ -28,12 +27,13 @@ from archivist import about
 from archivist.archivist import Archivist
 from archivist.errors import ArchivistNotFoundError
 
-from ..testing.logger import set_logger, LOGGER
 from ..testing.asset import MyAsset
+from ..testing.logger import set_logger, LOGGER
 from ..testing.namespace import (
     assets_list,
     assets_read_by_signature,
 )
+from ..testing.parser import common_parser
 from ..testing.time_warp import TimeWarp
 
 
@@ -127,25 +127,8 @@ def run(ac, args):
 
 
 def entry():
-    parser = argparse.ArgumentParser(
-        description="Populates an Archivist install with devices from an Azure IoT Hub"
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        dest="verbose",
-        action="store_true",
-        default=False,
-        help="print verbose debugging",
-    )
-    parser.add_argument(
-        "-u",
-        "--url",
-        type=str,
-        dest="url",
-        action="store",
-        default="https://rkvst.poc.jitsuin.io",
-        help="location of Archivist service",
+    parser, _ = common_parser(
+        "Populates an Archivist install with devices from an Azure IoT Hub"
     )
     parser.add_argument(
         "--namespace",
@@ -194,28 +177,6 @@ def entry():
         help="Fast forward time in event series (default: 1 second = 1 hour)",
     )
 
-    security = parser.add_mutually_exclusive_group(required=True)
-    security.add_argument(
-        "-t",
-        "--auth-token",
-        type=str,
-        dest="auth_token_file",
-        action="store",
-        default=".auth_token",
-        help="FILE containing API authentication token",
-    )
-    security.add_argument(
-        "-c",
-        "--clientcert",
-        type=str,
-        dest="client_cert_name",
-        action="store",
-        help=(
-            "name of TLS client cert (.key and .pem with matching name"
-            "must be in current directory)"
-        ),
-    )
-
     args = parser.parse_args()
 
     if args.verbose:
@@ -241,6 +202,7 @@ def entry():
     poc.namespace = (
         "_".join(["synsation", args.namespace]) if args.namespace is not None else None
     )
+    poc.storage_integrity = args.storage_integrity
 
     run(poc, args)
 

--- a/archivist_samples/testing/namespace.py
+++ b/archivist_samples/testing/namespace.py
@@ -26,6 +26,7 @@ from copy import deepcopy
 from archivist.errors import (
     ArchivistNotFoundError,
 )
+from archivist.storage_integrity import StorageIntegrity
 
 
 NAMESPACE_KEY = "functests_namespace"
@@ -81,7 +82,17 @@ def assets_read_by_signature(arch, attrs):
 
 
 def assets_create(arch, behaviours, attrs, *, confirm=False):
-    return arch.assets.create(behaviours, __newattrs(arch, attrs), confirm=confirm)
+    try:
+        storage_integrity = arch.storage_integrity
+    except AttributeError:
+        storage_integrity = StorageIntegrity.TENANT_STORAGE
+
+    return arch.assets.create(
+        behaviours,
+        __newattrs(arch, attrs),
+        storage_integrity=storage_integrity,
+        confirm=confirm,
+    )
 
 
 def assets_wait_for_confirmed(arch, attrs):

--- a/archivist_samples/testing/parser.py
+++ b/archivist_samples/testing/parser.py
@@ -1,0 +1,98 @@
+"""common parser arguments for all samples code
+"""
+
+# pylint:  disable=missing-docstring
+# pylint:  disable=too-few-public-methods
+
+
+import argparse
+from enum import Enum
+
+from archivist.storage_integrity import StorageIntegrity
+
+
+# from https://stackoverflow.com/questions/43968006/support-for-enum-arguments-in-argparse
+class EnumAction(argparse.Action):
+    """
+    Argparse action for handling Enums
+    """
+
+    def __init__(self, **kwargs):
+        # Pop off the type value
+        enum_type = kwargs.pop("type", None)
+
+        # Ensure an Enum subclass is provided
+        if enum_type is None:
+            raise ValueError("type must be assigned an Enum when using EnumAction")
+
+        if not issubclass(enum_type, Enum):
+            raise TypeError("type must be an Enum when using EnumAction")
+
+        # Generate choices from the Enum
+        kwargs.setdefault("choices", tuple(e.name for e in enum_type))
+
+        super().__init__(**kwargs)
+
+        self._enum = enum_type
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        # Convert value back into an Enum
+        value = self._enum[values]
+        setattr(namespace, self.dest, value)
+
+
+def common_parser(description):
+    """Contruct parser with security option for token/auth authentication"""
+    parser = argparse.ArgumentParser(
+        description=description,
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        default=False,
+        help="print verbose debugging",
+    )
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        dest="url",
+        action="store",
+        default="https://rkvst.poc.jitsuin.io",
+        help="location of Archivist service",
+    )
+    parser.add_argument(
+        "-i",
+        "--storage-integrity",
+        type=StorageIntegrity,
+        action=EnumAction,
+        dest="storage_integrity",
+        default=StorageIntegrity.TENANT_STORAGE,
+        help="Assets will be created on the ledger or on tenant storage",
+    )
+
+    security = parser.add_mutually_exclusive_group(required=True)
+    security.add_argument(
+        "-t",
+        "--auth-token",
+        type=str,
+        dest="auth_token_file",
+        action="store",
+        default=".auth_token",
+        help="FILE containing API authentication token",
+    )
+    security.add_argument(
+        "-c",
+        "--clientcert",
+        type=str,
+        dest="client_cert_name",
+        action="store",
+        help=(
+            "name of TLS client cert (.key and .pem with matching name must"
+            "be in current directory)"
+        ),
+    )
+
+    return parser, security

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cryptography==3.3.2
 importlib_resources==5.2.0 ; python_version == '3.6'
-jitsuin-archivist==0.2.0a2
+jitsuin-archivist==0.3.0a1
 pyyaml==5.4.1

--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -13,10 +13,11 @@ docker run \
     -v $(pwd):/home/api \
     -u $(id -u):$(id -g) \
     -e TEST_ARCHIVIST \
-    -e TEST_AUTHTOKEN \
+    -e TEST_AUTHTOKEN_FILENAME \
     -e TEST_NAMESPACE \
     -e TEST_SELECTOR \
     -e TEST_VERBOSE \
+    -e TEST_STORAGE_INTEGRITY \
     -e TWINE_USERNAME \
     -e TWINE_PASSWORD \
     jitsuin-samples-api \

--- a/scripts/samples.sh
+++ b/scripts/samples.sh
@@ -8,14 +8,14 @@ then
     echo "TEST_ARCHIVIST is undefined"
     exit 1
 fi
-if [ -z "${TEST_AUTHTOKEN}" ]
+if [ -z "${TEST_AUTHTOKEN_FILENAME}" ]
 then
-    echo "TEST_AUTHTOKEN is undefined"
+    echo "TEST_AUTHTOKEN_FILENAME is undefined"
     exit 1
 fi
-if [ ! -s "${TEST_AUTHTOKEN}" ]
+if [ ! -s "${TEST_AUTHTOKEN_FILENAME}" ]
 then
-    echo "${TEST_AUTHTOKEN} does not exist"
+    echo "${TEST_AUTHTOKEN_FILENAME} does not exist"
     exit 1
 fi
 
@@ -71,7 +71,7 @@ do
 done
 
 export PYTHONWARNINGS="ignore:Unverified HTTPS request"
-ARGS="-u $TEST_ARCHIVIST -t $TEST_AUTHTOKEN ${TEST_VERBOSE}"
+ARGS="-u $TEST_ARCHIVIST -t $TEST_AUTHTOKEN_FILENAME $TEST_VERBOSE $TEST_STORAGE_INTEGRITY"
 
 # namespacing ensures that each run  of the tests is independent.
 if [ -n "$TEST_NAMESPACE" ]


### PR DESCRIPTION
Problem:
New release of SAAS and python SDK supports storing evidence
on the ledger or tenant storage (a lower cost solution)

Solution:
Use 0.3.0a1 version of python SDK and specify LEDGER for SBOM
sample. Other code is left as-is (which will currently default to
LEDGER bu, at some later date) default to TENANT_STORAGE,

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>