### PR TITLE
Latest features of pythonSDK

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -39,7 +39,7 @@ export TEST_ARCHIVIST="https://rkvst.poc.jitsuin.io"
 export TEST_AUTHTOKEN_FILENAME=credentials/.auth_token
 export TEST_NAMESPACE="unique label"
 export TEST_VERBOSE=-v
-export TEST_STORAGE_INTEGRITY="--storage-integrity TENANT_STORAGE"
+export TEST_STORAGE_INTEGRITY="-i TENANT_STORAGE"
 ```
 
 If TEST_VERBOSE is "-v" debugging output will appear when running the tests.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Use the standard python pip utility:
 python3 -m pip install --user jitsuin-archivist-samples
 ```
 
-and this will create 5 entry points:
+and this will create 6 entry points:
 
       - archivist_samples_door_entry
       - archivist_samples_estate_info

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -49,7 +49,7 @@ tasks:
       - ./scripts/api.sh black archivist_samples
 
   publish:
-    desc: pubish wheel package (will require username and password in TWINE_USERNAME,TWINE_PASSWORD)
+    desc: publish wheel package (will require username and password in TWINE_USERNAME,TWINE_PASSWORD)
     deps: [about]
     cmds:
       - ./scripts/api.sh python3 -m twine check dist/*

--- a/archivist_samples/door_entry/main.py
+++ b/archivist_samples/door_entry/main.py
@@ -16,14 +16,17 @@
 
 # pylint:  disable=missing-docstring
 
-
+import logging
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
-from ..testing.logger import set_logger
-from ..testing.parser import common_parser, common_endpoint
+from archivist.parser import common_parser
+
+from ..testing.parser import common_endpoint
 
 from .run import run
+
+LOGGER = logging.getLogger(__name__)
 
 
 def main():
@@ -78,11 +81,6 @@ def main():
     )
 
     args = parser.parse_args()
-
-    if args.verbose:
-        set_logger("DEBUG")
-    else:
-        set_logger("INFO")
 
     poc = common_endpoint("door_entry", args)
 

--- a/archivist_samples/door_entry/run.py
+++ b/archivist_samples/door_entry/run.py
@@ -23,7 +23,7 @@ except ImportError:
     # Try backported to PY<37 `importlib_resources`.
     import importlib_resources as pkg_resources
 
-from copy import deepcopy
+from copy import copy
 import logging
 from sys import exit as sys_exit
 import uuid
@@ -653,7 +653,7 @@ def run(poc, args):
 
     LOGGER.info("Using version %s of jitsuin-archivist", about.__version__)
 
-    doors = deepcopy(poc)
+    doors = copy(poc)
     doors.fixtures = {
         "assets": {
             "attributes": {
@@ -661,7 +661,7 @@ def run(poc, args):
             },
         }
     }
-    cards = deepcopy(poc)
+    cards = copy(poc)
     cards.fixtures = {
         "assets": {
             "attributes": {

--- a/archivist_samples/estate_info/main.py
+++ b/archivist_samples/estate_info/main.py
@@ -20,13 +20,16 @@
 
 
 from collections import Counter
+import logging
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
 from archivist import about
+from archivist.parser import common_parser
 
-from ..testing.logger import set_logger, LOGGER
-from ..testing.parser import common_parser, common_endpoint
+from ..testing.parser import common_endpoint
+
+LOGGER = logging.getLogger(__name__)
 
 # Main app
 ##########
@@ -109,11 +112,6 @@ def main():
     )
 
     args = parser.parse_args()
-
-    if args.verbose:
-        set_logger("DEBUG")
-    else:
-        set_logger("INFO")
 
     poc = common_endpoint("estate_info", args)
 

--- a/archivist_samples/signed_records/main.py
+++ b/archivist_samples/signed_records/main.py
@@ -21,6 +21,7 @@
 
 
 import base64
+import logging
 import os
 
 from sys import exit as sys_exit
@@ -38,10 +39,12 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat import backends
 
 from archivist import about
+from archivist.parser import common_parser
 from archivist.errors import ArchivistNotFoundError
 
-from ..testing.logger import set_logger, LOGGER
-from ..testing.parser import common_parser, common_endpoint
+from ..testing.parser import common_endpoint
+
+LOGGER = logging.getLogger(__name__)
 
 # Key management functions
 #
@@ -432,11 +435,6 @@ def main():
     parser.add_argument("asset_name")
 
     args = parser.parse_args()
-
-    if args.verbose:
-        set_logger("DEBUG")
-    else:
-        set_logger("INFO")
 
     poc = common_endpoint("signed_records", args)
 

--- a/archivist_samples/software_bill_of_materials/README.md
+++ b/archivist_samples/software_bill_of_materials/README.md
@@ -139,7 +139,7 @@ In order to control data sharing to restrict general customers to see only the r
       "access_permissions": [
         {
           "subjects": [ "subjects/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" ],
-          "behaviours": [ "RecordEvidence" ],
+          "behaviours": [ "Attachments", "RecordEvidence" ],
           "include_attributes": [],
           "user_attributes": [],
           "asset_attributes_read": [

--- a/archivist_samples/software_bill_of_materials/main.py
+++ b/archivist_samples/software_bill_of_materials/main.py
@@ -16,14 +16,17 @@
 
 # pylint:  disable=missing-docstring
 
-
+import logging
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
-from ..testing.logger import set_logger
-from ..testing.parser import common_parser, common_endpoint
+from archivist.parser import common_parser
+
+from ..testing.parser import common_endpoint
 
 from .run import run
+
+LOGGER = logging.getLogger(__name__)
 
 
 def main():
@@ -40,11 +43,6 @@ def main():
     )
 
     args = parser.parse_args()
-
-    if args.verbose:
-        set_logger("DEBUG")
-    else:
-        set_logger("INFO")
 
     poc = common_endpoint("sbom", args)
 

--- a/archivist_samples/synsation/analyze.py
+++ b/archivist_samples/synsation/analyze.py
@@ -20,10 +20,12 @@
 
 
 from datetime import datetime, timezone
+import logging
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
 from archivist import about
+from archivist.parser import common_parser
 from archivist.timestamp import parse_timestamp
 
 from ..testing.asset import (
@@ -33,8 +35,9 @@ from ..testing.asset import (
     VULNERABILITY_REPORT,
 )
 
-from ..testing.logger import set_logger, LOGGER
-from ..testing.parser import common_parser, common_endpoint
+from ..testing.parser import common_endpoint
+
+LOGGER = logging.getLogger(__name__)
 
 
 def analyze_matched_pairs(label, p1, p2, events):
@@ -155,11 +158,6 @@ def entry():
     # per example options here ....
 
     args = parser.parse_args()
-
-    if args.verbose:
-        set_logger("DEBUG")
-    else:
-        set_logger("INFO")
 
     poc = common_endpoint("synsation", args)
 

--- a/archivist_samples/synsation/charger.py
+++ b/archivist_samples/synsation/charger.py
@@ -21,21 +21,23 @@
 # pylint:  disable=missing-docstring
 
 import datetime
+import logging
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 import threading
 import time
 
 from archivist import about
+from archivist.parser import common_parser
 
-from ..testing.logger import set_logger, LOGGER
-
-from ..testing.parser import common_parser, common_endpoint
+from ..testing.parser import common_endpoint
 from ..testing.time_warp import TimeWarp
 
 from . import ev_charger_device
 from . import device_worker
 from . import recall_worker
+
+LOGGER = logging.getLogger(__name__)
 
 
 def initialize_devices(conn, airport):
@@ -193,11 +195,6 @@ def entry():
     )
 
     args = parser.parse_args()
-
-    if args.verbose:
-        set_logger("DEBUG")
-    else:
-        set_logger("INFO")
 
     poc = common_endpoint("synsation", args)
 

--- a/archivist_samples/synsation/initialise.py
+++ b/archivist_samples/synsation/initialise.py
@@ -18,19 +18,22 @@
 
 # pylint:  disable=missing-docstring
 
-
+import logging
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
 from archivist import about
+from archivist.parser import common_parser
 
-from ..testing.logger import set_logger, LOGGER
-from ..testing.parser import common_parser, common_endpoint
+from ..testing.parser import common_endpoint
 
 from . import synsation_corporation
 from . import synsation_industries
 from . import synsation_manufacturing
 from . import synsation_smartcity
+
+LOGGER = logging.getLogger(__name__)
+
 
 # Main app
 ##########
@@ -131,11 +134,6 @@ def entry():
     )
 
     args = parser.parse_args()
-
-    if args.verbose:
-        set_logger("DEBUG")
-    else:
-        set_logger("INFO")
 
     poc = common_endpoint("synsation", args)
 

--- a/archivist_samples/synsation/jitsuinator.py
+++ b/archivist_samples/synsation/jitsuinator.py
@@ -22,6 +22,7 @@
 
 
 import datetime
+import logging
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 import time
@@ -29,13 +30,15 @@ import uuid
 
 from archivist import about
 from archivist.errors import ArchivistNotFoundError
+from archivist.parser import common_parser
 
 from ..testing.asset import MyAsset
-from ..testing.logger import set_logger, LOGGER
-from ..testing.parser import common_parser, common_endpoint
+from ..testing.parser import common_endpoint
 from ..testing.time_warp import TimeWarp
 
 from .util import attachment_upload_from_file
+
+LOGGER = logging.getLogger(__name__)
 
 
 def demo_flow(ac, asset_id, asset_type, tw, wait):
@@ -234,11 +237,6 @@ def entry():
     )
 
     args = parser.parse_args()
-
-    if args.verbose:
-        set_logger("DEBUG")
-    else:
-        set_logger("INFO")
 
     poc = common_endpoint("synsation", args)
     run(poc, args)

--- a/archivist_samples/synsation/wanderer.py
+++ b/archivist_samples/synsation/wanderer.py
@@ -19,17 +19,20 @@
 # pylint: disable=logging-fstring-interpolation
 
 import datetime
+import logging
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 import time
 
 from archivist import about
 from archivist.errors import ArchivistNotFoundError
+from archivist.parser import common_parser
 
 from ..testing.asset import MyAsset
-from ..testing.logger import set_logger, LOGGER
-from ..testing.parser import common_parser, common_endpoint
+from ..testing.parser import common_endpoint
 from ..testing.time_warp import TimeWarp
+
+LOGGER = logging.getLogger(__name__)
 
 
 # Archivist utilities
@@ -172,11 +175,6 @@ def entry():
     )
 
     args = parser.parse_args()
-
-    if args.verbose:
-        set_logger("DEBUG")
-    else:
-        set_logger("INFO")
 
     poc = common_endpoint("synsation", args)
     run(poc, args)

--- a/archivist_samples/testing/parser.py
+++ b/archivist_samples/testing/parser.py
@@ -5,121 +5,29 @@
 # pylint:  disable=too-few-public-methods
 
 
-import argparse
-from enum import Enum
 import logging
-from sys import exit as sys_exit
 
-from archivist.archivist import Archivist
-from archivist.storage_integrity import StorageIntegrity
+from archivist.parser import endpoint
 
 LOGGER = logging.getLogger(__name__)
 
 
-# from https://stackoverflow.com/questions/43968006/support-for-enum-arguments-in-argparse
-class EnumAction(argparse.Action):
-    """
-    Argparse action for handling Enums
-    """
-
-    def __init__(self, **kwargs):
-        # Pop off the type value
-        enum_type = kwargs.pop("type", None)
-
-        # Ensure an Enum subclass is provided
-        if enum_type is None:
-            raise ValueError("type must be assigned an Enum when using EnumAction")
-
-        if not issubclass(enum_type, Enum):
-            raise TypeError("type must be an Enum when using EnumAction")
-
-        # Generate choices from the Enum
-        kwargs.setdefault("choices", tuple(e.name for e in enum_type))
-
-        super().__init__(**kwargs)
-
-        self._enum = enum_type
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        # Convert value back into an Enum
-        value = self._enum[values]
-        setattr(namespace, self.dest, value)
-
-
-def common_parser(description):
-    """Contruct parser with security option for token/auth authentication"""
-    parser = argparse.ArgumentParser(
-        description=description,
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        dest="verbose",
-        action="store_true",
-        default=False,
-        help="print verbose debugging",
-    )
-    parser.add_argument(
-        "-u",
-        "--url",
-        type=str,
-        dest="url",
-        action="store",
-        default="https://rkvst.poc.jitsuin.io",
-        help="location of Archivist service",
-    )
-    parser.add_argument(
-        "-i",
-        "--storage-integrity",
-        type=StorageIntegrity,
-        action=EnumAction,
-        dest="storage_integrity",
-        default=StorageIntegrity.TENANT_STORAGE,
-        help="Assets will be created on the ledger or on tenant storage",
-    )
-
-    security = parser.add_mutually_exclusive_group(required=True)
-    security.add_argument(
-        "-t",
-        "--auth-token",
-        type=str,
-        dest="auth_token_file",
-        action="store",
-        default=".auth_token",
-        help="FILE containing API authentication token",
-    )
-    security.add_argument(
-        "-c",
-        "--clientcert",
-        type=str,
-        dest="client_cert_name",
-        action="store",
-        help=(
-            "name of TLS client cert (.key and .pem with matching name must"
-            "be in current directory)"
-        ),
-    )
-
-    return parser, security
-
-
 def common_endpoint(label, args):
-    LOGGER.info("Initialising connection to Jitsuin Archivist...")
+    LOGGER.info(
+        "Initialising connectStorageIntegrityStorageIntegrityion to Jitsuin Archivist..."
+    )
+    arch = endpoint(args)
+
     try:
         namespace = (
             "_".join([label, args.namespace]) if args.namespace is not None else label
         )
     except AttributeError:
-        fixtures = {
-            "assets": {
-                "storage_integrity": args.storage_integrity.name,
-            },
-        }
+        pass
 
     else:
-        fixtures = {
+        arch.fixtures = {
             "assets": {
-                "storage_integrity": args.storage_integrity.name,
                 "attributes": {
                     "arc_namespace": namespace,
                 },
@@ -131,19 +39,4 @@ def common_endpoint(label, args):
             },
         }
 
-    if args.auth_token_file:
-        with open(args.auth_token_file, mode="r") as tokenfile:
-            authtoken = tokenfile.read().strip()
-
-        poc = Archivist(args.url, auth=authtoken, verify=False, fixtures=fixtures)
-
-    elif args.client_cert_name:
-        poc = Archivist(
-            args.url, cert=args.client_cert_name, verify=False, fixtures=fixtures
-        )
-
-    if poc is None:
-        LOGGER.error("Critical error.  Aborting.")
-        sys_exit(1)
-
-    return poc
+    return arch

--- a/archivist_samples/wipp/main.py
+++ b/archivist_samples/wipp/main.py
@@ -16,14 +16,17 @@
 
 # pylint:  disable=missing-docstring
 
-
+import logging
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
-from ..testing.logger import set_logger
-from ..testing.parser import common_parser, common_endpoint
+from archivist.parser import common_parser
+
+from ..testing.parser import common_endpoint
 
 from .run import run
+
+LOGGER = logging.getLogger(__name__)
 
 
 def main():
@@ -38,11 +41,6 @@ def main():
     )
 
     args = parser.parse_args()
-
-    if args.verbose:
-        set_logger("DEBUG")
-    else:
-        set_logger("INFO")
 
     poc = common_endpoint("wipp", args)
 

--- a/archivist_samples/wipp/run.py
+++ b/archivist_samples/wipp/run.py
@@ -56,7 +56,6 @@ def run(arch, args):
     # Wipp class encapsulates wipp object in RKVST
     LOGGER.info("Creating Drum Asset...")
     drum = Wipp(arch, "55 gallon drum")
-    cask = Wipp(arch, "TRU RH 72B Cask")
     serial_num = "".join(
         random.choice(string.ascii_lowercase + string.digits) for _ in range(12)
     )
@@ -81,6 +80,7 @@ def run(arch, args):
     )
     caskname = "Cask-" + serial_num
 
+    cask = Wipp(arch, "TRU RH 72B Cask")
     cask.create(
         caskname,
         "NRC certified type-B road shipping container, capacity 3 x 55-gallon drum",

--- a/archivist_samples/wipp/wipp.py
+++ b/archivist_samples/wipp/wipp.py
@@ -2,7 +2,7 @@
 # pylint:disable=missing-module-docstring      # docstrings
 # pylint:disable=missing-class-docstring      # docstrings
 
-from copy import deepcopy
+from copy import copy
 from typing import Optional
 
 # pylint:disable=unused-import      # To prevent cyclical import errors forward referencing is used
@@ -17,7 +17,7 @@ class Wipp:
         arch: "type_helper.Archivist",
         display_type: str,
     ):
-        arch_ = deepcopy(arch)
+        arch_ = copy(arch)
         arch_.fixtures = {
             "assets": {
                 "attributes": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cryptography==3.3.2
 importlib_resources==5.2.0 ; python_version == '3.6'
-jitsuin-archivist==0.4.0b1
+jitsuin-archivist==0.5.0
 pyyaml==5.4.1

--- a/scripts/samples.sh
+++ b/scripts/samples.sh
@@ -27,10 +27,10 @@ then
     echo "    TEST_SELECTOR=estate_info ${SAMPLESCMD}"
     echo "    TEST_SELECTOR=signed_records ${SAMPLESCMD}"
     echo "    TEST_SELECTOR=synsation_initialise ${SAMPLESCMD}"
-    echo "    TEST_SELECTOR=synsation_analyze ${SAMPLESCMD}"
     echo "    TEST_SELECTOR=synsation_charger ${SAMPLESCMD}"
     echo "    TEST_SELECTOR=synsation_jitsuinator ${SAMPLESCMD}"
     echo "    TEST_SELECTOR=synsation_wanderer ${SAMPLESCMD}"
+    echo "    TEST_SELECTOR=synsation_analyze ${SAMPLESCMD}"
     echo "    TEST_SELECTOR=sbom ${SAMPLESCMD}"
     echo "    TEST_SELECTOR=wipp ${SAMPLESCMD}"
     echo ""
@@ -41,6 +41,11 @@ then
     echo "To run all tests:"
     echo ""
     echo "    TEST_SELECTOR=all ${SAMPLESCMD}"
+    echo ""
+    echo "Additionally:"
+    echo ""
+    echo "    TEST_NAMESPACE=$TEST_NAMESPACE"
+    echo "    TEST_VERBOSE=$TEST_VERBOSE"
     echo ""
     exit 0
 fi
@@ -122,9 +127,6 @@ ${SIGNED_RECORDS} --check 'samples'
 SYNSATION_INITIALISE="${TEST_NO_SYNSATION_INITIALISE} python3 -m archivist_samples.synsation initialise ${ARGS} ${NAMESPACE}"
 ${SYNSATION_INITIALISE} --num-assets 100 --wait 1 --await-confirmation
 
-SYNSATION_ANALYZE="${TEST_NO_SYNSATION_ANALYZE} python3 -m archivist_samples.synsation analyze ${ARGS} ${NAMESPACE}"
-${SYNSATION_ANALYZE}
-
 SYNSATION_CHARGER="${TEST_NO_SYNSATION_CHARGER} python3 -m archivist_samples.synsation charger ${ARGS} ${NAMESPACE}"
 ${SYNSATION_CHARGER} -s 20190909 -S 20190923 -f 9876
 
@@ -133,6 +135,9 @@ ${SYNSATION_JITSUINATOR} -n tcl.ccj.001 --wait 1.0
 
 SYNSATION_WANDERER="${TEST_NO_SYNSATION_WANDERER} python3 -m archivist_samples.synsation wanderer ${ARGS} ${NAMESPACE}"
 ${SYNSATION_WANDERER}
+
+SYNSATION_ANALYZE="${TEST_NO_SYNSATION_ANALYZE} python3 -m archivist_samples.synsation analyze ${ARGS} ${NAMESPACE}"
+${SYNSATION_ANALYZE}
 
 SBOM="${TEST_NO_SBOM} python3 -m archivist_samples.software_bill_of_materials ${ARGS} ${NAMESPACE}"
 ${SBOM}


### PR DESCRIPTION
Problem:
Common code is moved to pythonSDK.

Solution:
Use latest pythonSDK 0.5.0 and remove unneeded code.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>