### PR TITLE
Git versioning is broken

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,0 @@
-
-[build-system]
-requires = [ "setuptools>=41", "wheel", "setuptools-git-versioning==1.7.4", ]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools-git-versioning]
-enabled = true

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,15 @@ setup(
         'Topic :: Utilities' # https://pypi.org/classifiers/ # check another option client-sdk
     ],
     install_requires=requirements,
+    version_config={
+        "template": "{tag}",
+        "dev_template": "{tag}.post{ccount}+git.{sha}",
+        "dirty_template": "{tag}.post{ccount}+git.{sha}.dirty",
+        "version_callback": None,
+        "version_file": None,
+        "count_commits_from_version_file": False,
+    },
+    setup_requires=['setuptools-git-versioning==1.7.4'],
     python_requires='>=3.6',
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Problem:
Tagging a release results in a version of 0.0.0.

Solution:
Pinned setuptools-git-versioning to v1.7.4 as later versions use
pyproject.tml and do not support python 3.6

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>