### PR TITLE
Fix missing package data in wheel

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -68,6 +68,6 @@ tasks:
 
   wheel:
     desc: Builds python wheel package
-    deps: [about]
+    deps: [about, clean]
     cmds:
       - ./scripts/api.sh ./scripts/wheel.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cryptography~=38.0
-jitsuin-archivist==0.17.4
+jitsuin-archivist==0.17.5
 pyyaml~=5.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,17 @@ project_urls =
 
 [options]
 install_requires = file: requirements.txt
-packages = archivist_samples
+packages = 
+    archivist_samples
+    archivist_samples/testing
+    archivist_samples/door_entry
+    archivist_samples/estate_info
+    archivist_samples/signed_records
+    archivist_samples/software_bill_of_materials
+    archivist_samples/synsation
+    archivist_samples/wipp
+
+include_package_data = True
 platforms = any
 python_requires = >=3.7
 setup_requires = setuptools-git-versioning


### PR DESCRIPTION
Problem:
Entry points and package date was missing from wheel.

Solution:
Modified setup.cfg.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>