### PR TITLE
Remove universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,3 @@ console_scripts =
     archivist_samples_software_bill_of_materials = archivist_samples.software_bill_of_materials.main:main
     archivist_samples_sbom_document = archivist_samples.sbom_document.main:main
     archivist_samples_wipp = archivist_samples.wipp.main:main
-
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
This fixes failure in the publishing pipeline where universal wheels are no longer supported.

Non-functional

[AB#10628](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/10628)